### PR TITLE
Update to elm-test 4.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,17 @@ module.exports = {
     "node": true
   },
   "extends": ["google"],
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "plugins": [
     "standard",
     "promise"
   ],
   "rules": {
+    "comma-dangle": 0,
     "max-len": ["error", 120],
+    "no-var": 0,
     "require-jsdoc": 0
   }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ npm-debug.log
 # elm
 elm-stuff
 
+# elm-test-extra
+plugin/elm-test-extra/ElmTest/
+
 # tests
 coverage
 test/**/tests/elm-package.json

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="EslintConfiguration">
-    <custom-configuration-file used="false" path="$PROJECT_DIR$/.eslintrc.js" />
-  </component>
-</project>

--- a/.idea/markdown-exported-files.xml
+++ b/.idea/markdown-exported-files.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownExportedFiles">
+    <htmlFiles />
+    <imageFiles />
+    <otherFiles />
+  </component>
+</project>

--- a/.idea/markdown-navigator.xml
+++ b/.idea/markdown-navigator.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownProjectSettings">
+    <PreviewSettings splitEditorLayout="FIRST" splitEditorPreview="PREVIEW" useGrayscaleRendering="false" zoomFactor="1.0" maxImageWidth="900" showGitHubPageIfSynced="false" allowBrowsingInPreview="false" synchronizePreviewPosition="false" highlightPreviewType="LINE" highlightFadeOut="5" highlightOnTyping="false" synchronizeSourcePosition="false">
+      <PanelProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.panel" providerName="Default - Swing" />
+      </PanelProvider>
+    </PreviewSettings>
+    <ParserSettings>
+      <PegdownExtensions>
+        <option name="ABBREVIATIONS" value="false" />
+        <option name="ANCHORLINKS" value="true" />
+        <option name="ATXHEADERSPACE" value="false" />
+        <option name="AUTOLINKS" value="true" />
+        <option name="DEFINITIONS" value="true" />
+        <option name="FENCED_CODE_BLOCKS" value="true" />
+        <option name="FOOTNOTES" value="false" />
+        <option name="FORCELISTITEMPARA" value="false" />
+        <option name="HARDWRAPS" value="true" />
+        <option name="QUOTES" value="false" />
+        <option name="RELAXEDHRULES" value="true" />
+        <option name="SMARTS" value="false" />
+        <option name="STRIKETHROUGH" value="true" />
+        <option name="SUPPRESS_HTML_BLOCKS" value="false" />
+        <option name="SUPPRESS_INLINE_HTML" value="false" />
+        <option name="TABLES" value="true" />
+        <option name="TASKLISTITEMS" value="true" />
+        <option name="TOC" value="false" />
+        <option name="TRACE_PARSER" value="false" />
+        <option name="WIKILINKS" value="true" />
+      </PegdownExtensions>
+      <ParserOptions>
+        <option name="COMMONMARK_LISTS" value="false" />
+        <option name="DUMMY" value="false" />
+        <option name="EMOJI_SHORTCUTS" value="true" />
+        <option name="FLEXMARK_FRONT_MATTER" value="false" />
+        <option name="GFM_TABLE_RENDERING" value="true" />
+        <option name="GITBOOK_URL_ENCODING" value="false" />
+        <option name="GITHUB_EMOJI_URL" value="false" />
+        <option name="GITHUB_LISTS" value="false" />
+        <option name="GITHUB_WIKI_LINKS" value="true" />
+        <option name="JEKYLL_FRONT_MATTER" value="false" />
+        <option name="SIM_TOC_BLANK_LINE_SPACER" value="false" />
+      </ParserOptions>
+    </ParserSettings>
+    <HtmlSettings headerTopEnabled="false" headerBottomEnabled="false" bodyTopEnabled="false" bodyBottomEnabled="false" embedUrlContent="false" addPageHeader="true">
+      <GeneratorProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.generator" providerName="Default Swing HTML Generator" />
+      </GeneratorProvider>
+      <headerTop />
+      <headerBottom />
+      <bodyTop />
+      <bodyBottom />
+    </HtmlSettings>
+    <CssSettings previewScheme="UI_SCHEME" cssUri="" isCssUriEnabled="false" isCssTextEnabled="false" isDynamicPageWidth="true">
+      <StylesheetProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.css" providerName="Default Swing Stylesheet" />
+      </StylesheetProvider>
+      <ScriptProviders />
+      <cssText />
+    </CssSettings>
+    <HtmlExportSettings updateOnSave="false" parentDir="$ProjectFileDir$" targetDir="$ProjectFileDir$" cssDir="" scriptDir="" plainHtml="false" imageDir="" copyLinkedImages="false" imageUniquifyType="0" targetExt="" useTargetExt="false" noCssNoScripts="false" linkToExportedHtml="true" exportOnSettingsChange="true" regenerateOnProjectOpen="false" />
+    <LinkMapSettings>
+      <textMaps />
+    </LinkMapSettings>
+  </component>
+</project>

--- a/.idea/markdown-navigator/profiles_settings.xml
+++ b/.idea/markdown-navigator/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="MarkdownNavigator.ProfileManager">
+  <settings default="" pdf-export="" />
+</component>

--- a/.idea/runConfigurations/Integration___All.xml
+++ b/.idea/runConfigurations/Integration___All.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Integration - Mocha" type="mocha-javascript-test-runner" factoryName="Mocha" singleton="false">
+  <configuration default="false" name="Integration - All" type="mocha-javascript-test-runner" factoryName="Mocha" singleton="false">
     <node-interpreter>$USER_HOME$/.nvm/versions/node/v6.9.0/bin/node</node-interpreter>
     <node-options />
     <working-directory>$PROJECT_DIR$</working-directory>

--- a/.idea/runConfigurations/Integration___elm_test_extra_simple.xml
+++ b/.idea/runConfigurations/Integration___elm_test_extra_simple.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration - elm-test-extra-simple" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>$USER_HOME$/.nvm/versions/node/v6.9.0/bin/node</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="PATH" value="/Users/ben/.nvm/versions/node/v6.9.0/bin:/usr/bin:/usr/local/bin" />
+      <env name="disableClean" value="true" />
+      <env name="noisyTestRun" value="true" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>-t 100000</extra-mocha-options>
+    <test-kind>SUITE</test-kind>
+    <test-file>$PROJECT_DIR$/test/integration/elm-test-extra/simple/simple.test.js</test-file>
+    <test-names>
+      <name value="elm-test-extra-simple" />
+    </test-names>
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Integration___elm_test_simple.xml
+++ b/.idea/runConfigurations/Integration___elm_test_simple.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration - elm-test-simple" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>$USER_HOME$/.nvm/versions/node/v6.9.0/bin/node</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="PATH" value="/Users/ben/.nvm/versions/node/v6.9.0/bin:/usr/bin:/usr/local/bin" />
+      <env name="disableClean" value="true" />
+      <env name="noisyTestRun" value="true" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>-t 100000</extra-mocha-options>
+    <test-kind>SUITE</test-kind>
+    <test-file>$PROJECT_DIR$/test/integration/elm-test/simple/simple.test.js</test-file>
+    <test-names>
+      <name value="elm-test-simple" />
+    </test-names>
+    <method />
+  </configuration>
+</component>

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,9 @@
 # elm
 elm-stuff
 
+# elm-test-extra
+plugin/elm-test-extra/ElmTest/
+
 # tests
 coverage
 test/**/tests/elm-package.json

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ all =
 
 The following elm-test functions are not available in elm-test-extra:
 * concat -> instead use `describe`
-* filter -> instead use `skip`
+
+Note: the use of skip in lobo requires a reason to be specified
 
 ## Typical Workflow
 Assuming your application follows the recommended directory structure 
@@ -209,7 +210,7 @@ The following test frameworks are supported:
 
 ### elm-test-extra
 elm-test-extra is the default framework, it is similar to elm-test with
-additions for focusing and skipping tests.
+additions for running test.
 
 The following options are supported elm-test-extra:
 * runCount - run count for fuzz tests; defaults to 100 
@@ -237,9 +238,16 @@ assertion it adds a visual hint for the source of the difference:
 </p>
  
 The following options are supported by the default reporter:
-* failOnFocus - exit with non zero exit code when there are any focused 
+* failOnOnly - exit with non zero exit code when there are any only
 tests
-* showSkipped - report skipped tests and the reasons after the summary.
+* failOnSkip - exit with non zero exit code when there are any skip
+tests
+* failOnTodo - exit with non zero exit code when there are any todo
+tests
+* showSkip - report skipped tests and the reasons after the summary.
+This option is only available with elm-test-extra and is ignored when
+the quiet option is present
+* showTodo - report skipped tests and the reasons after the summary.
 This option is ignored when the quiet option is present
 
 ## Troubleshooting

--- a/bin/lobo.js
+++ b/bin/lobo.js
@@ -87,11 +87,6 @@ function done(config) {
 
 function watch(config) {
   var paths = ['./elm-package.json'];
-
-  // paths.push(__dirname);
-  // paths.push(path.normalize(__dirname + '/../lib'));
-  // paths.push(path.normalize(__dirname + '/../plugin/default-reporter'));
-
   var testElmPackage = builder.readElmPackageJson(path.join(program.testDirectory, 'elm-package.json'));
 
   if (testElmPackage && testElmPackage['source-directories']) {
@@ -150,7 +145,7 @@ function configure() {
   });
 
   program
-    .version('0.0.1')
+    .version('0.2.0')
     .option('--compiler <value>', 'path to compiler')
     .option('--debug', 'disables auto-cleanup of temp files')
     .option('--framework <value>', 'name of the testing framework to use', 'elm-test-extra')
@@ -259,6 +254,15 @@ function validateConfiguration() {
     logger.info('You can override the default location ("./tests") by running:');
     logger.info('lobo --testDirectory [directory containing Tests.elm]');
     exit = true;
+  }
+
+  if(program.framework === 'elm-test') {
+    if(program.showSkipped) {
+      logger.error('');
+      logger.error('Invalid configuration combination');
+      logger.error('--showSkipped is only available with the default test framework (elm-test-extra)');
+      exit = true;
+    }
   }
 
   if (exit === true) {

--- a/bin/lobo.js
+++ b/bin/lobo.js
@@ -257,10 +257,10 @@ function validateConfiguration() {
   }
 
   if(program.framework === 'elm-test') {
-    if(program.showSkipped) {
+    if(program.showSkip) {
       logger.error('');
       logger.error('Invalid configuration combination');
-      logger.error('--showSkipped is only available with the default test framework (elm-test-extra)');
+      logger.error('--showSkip is only available with the default test framework (elm-test-extra)');
       exit = true;
     }
   }

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,10 +11,10 @@
     "exposed-modules": [], 
     "dependencies": {
         "benansell/lobo-elm-test-extra": "1.0.1 <= v <= 2.0.0",
-        "elm-community/elm-test": "3.0.0 <= v < 4.0.0", 
-        "elm-lang/core": "5.0.0 <= v < 6.0.0", 
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0", 
-        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
+        "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0"
     }, 
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tmp": "^0.0.31"
   },
   "devDependencies": {
-    "chai": "^4.0.0",
+    "chai": "^3.5.0",
     "eslint": "^3.7.1",
     "eslint-config-google": "^0.7.1",
     "eslint-plugin-promise": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lobo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Elm test runner",
   "keywords": [
     "elm",
@@ -28,27 +28,27 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",
-    "chokidar": "^1.6.0",
+    "chokidar": "^1.7.0",
     "commander": "^2.9.0",
     "fast-levenshtein": "^2.0.5",
     "lodash": "^4.16.4",
-    "promptly": "^2.1.0",
-    "shelljs": "^0.7.4",
-    "tmp": "^0.0.29"
+    "promptly": "^2.2.0",
+    "shelljs": "^0.7.7",
+    "tmp": "^0.0.31"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.0.0",
     "eslint": "^3.7.1",
-    "eslint-config-google": "^0.6.0",
-    "eslint-plugin-promise": "^2.0.1",
-    "eslint-plugin-standard": "^2.0.1",
+    "eslint-config-google": "^0.7.1",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1",
     "istanbul": "^0.4.5",
-    "mocha": "^3.1.0",
+    "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.2.0",
     "rewire": "^2.5.2",
     "rimraf": "^2.5.4",
-    "sinon": "^1.17.6",
-    "sinon-chai": "^2.8.0"
+    "sinon": "^2.3.2",
+    "sinon-chai": "^2.10.0"
   },
   "scripts": {
     "clean": "rimraf node_modules",

--- a/plugin/default-reporter/plugin-config.js
+++ b/plugin/default-reporter/plugin-config.js
@@ -4,8 +4,11 @@ module.exports = function() {
   return {
     name: 'default-reporter',
     options: [
-      {flags: '--failOnFocus', description: 'exit with non zero exit code when there are any focused tests'},
-      {flags: '--showSkipped', description: 'Report skipped tests after the summary'}
+      {flags: '--failOnOnly', description: 'exit with non zero exit code when there are any only tests'},
+      {flags: '--failOnSkip', description: 'exit with non zero exit code when there are any skip tests'},
+      {flags: '--failOnTodo', description: 'exit with non zero exit code when there are any todo tests'},
+      {flags: '--showSkip', description: 'Report skipped tests after the summary'},
+      {flags: '--showTodo', description: 'Report todo tests after the summary'}
     ]
   };
 };

--- a/plugin/default-reporter/plugin-config.js
+++ b/plugin/default-reporter/plugin-config.js
@@ -7,8 +7,8 @@ module.exports = function() {
       {flags: '--failOnOnly', description: 'exit with non zero exit code when there are any only tests'},
       {flags: '--failOnSkip', description: 'exit with non zero exit code when there are any skip tests'},
       {flags: '--failOnTodo', description: 'exit with non zero exit code when there are any todo tests'},
-      {flags: '--showSkip', description: 'Report skipped tests after the summary'},
-      {flags: '--showTodo', description: 'Report todo tests after the summary'}
+      {flags: '--showSkip', description: 'report skipped tests after the summary'},
+      {flags: '--showTodo', description: 'report todo tests after the summary'}
     ]
   };
 };

--- a/plugin/default-reporter/reporter-plugin.js
+++ b/plugin/default-reporter/reporter-plugin.js
@@ -101,7 +101,10 @@ function logSummary(summary, failState) {
 
   if(program.framework !== 'elm-test') {
     // full run details not available when using elm-test
-    paddedLog(skipStyle('Skipped:  ' + summary.skippedCount));
+
+    if(summary.skippedCount > 0) {
+      paddedLog(skipStyle('Skipped:  ' + summary.skippedCount));
+    }
 
     if (summary.onlyCount > 0) {
       paddedLog(onlyStyle('Ignored:  ' + summary.onlyCount));

--- a/plugin/default-reporter/reporter-plugin.js
+++ b/plugin/default-reporter/reporter-plugin.js
@@ -9,7 +9,7 @@ var util = require('../../lib/util');
 var passedStyle = chalk.green;
 var failedStyle = chalk.red;
 var givenStyle = chalk.yellow;
-var inconclusiveStyle = chalk.yellow.dim;
+var inconclusiveStyle = chalk.yellow;
 var headerStyle = chalk.bold;
 var labelStyle = chalk.dim;
 var onlyStyle = undefined;
@@ -169,7 +169,7 @@ function sortItemsByLabel(item) {
 function logNonPassed(summary) {
   var itemList = _.clone(summary.failures);
 
-  if (program.showSkipped) {
+  if (program.showSkip) {
     itemList = itemList.concat(summary.skipped);
   }
 

--- a/plugin/elm-test-extra/plugin-config.js
+++ b/plugin/elm-test-extra/plugin-config.js
@@ -5,9 +5,9 @@ module.exports = function() {
     'name': 'elm-test-extra',
     'source-directories': ['runner', 'plugin/elm-test-extra'],
     'dependencies': {
-      'benansell/lobo-elm-test-extra': '1.0.1 <= v < 2.0.0',
-      'elm-community/elm-test': '3.0.0 <= v < 4.0.0',
-      'mgold/elm-random-pcg': '4.0.2 <= v < 5.0.0'
+      'benansell/lobo-elm-test-extra': '2.0.0 <= v < 3.0.0',
+      'elm-community/elm-test': '4.0.0 <= v < 5.0.0',
+      'mgold/elm-random-pcg': '5.0.0 <= v < 6.0.0'
     },
     'options': [
       {flags: '--seed <value>', description: 'initial seed value for fuzz tests; defaults to a random value'},

--- a/plugin/elm-test/plugin-config.js
+++ b/plugin/elm-test/plugin-config.js
@@ -5,8 +5,8 @@ module.exports = function() {
     'name': 'elm-test',
     'source-directories': ['runner', 'plugin/elm-test'],
     'dependencies': {
-      'elm-community/elm-test': '3.0.0 <= v < 4.0.0',
-      'mgold/elm-random-pcg': '4.0.2 <= v < 5.0.0'
+      'elm-community/elm-test': '4.0.0 <= v < 5.0.0',
+      'mgold/elm-random-pcg': '5.0.0 <= v < 6.0.0'
     },
     'options': [
       {flags: '--seed <value>', description: 'initial seed value for fuzz tests; defaults to a random value'},

--- a/runner/TestPlugin.elm
+++ b/runner/TestPlugin.elm
@@ -1,4 +1,4 @@
-module TestPlugin exposing (Args, FailureMessage, TestId, TestIdentifier, TestItem, TestResult(Fail, Ignore, Pass, Skip))
+module TestPlugin exposing (Args, FailureMessage, TestId, TestIdentifier, TestItem, TestResult(Fail, Ignore, Pass, Skip, Todo), TestRunType(Normal, Focusing, Skipping))
 
 import Time exposing (Time)
 
@@ -9,7 +9,7 @@ type alias Args a =
 
 
 type alias FailureMessage =
-    { given : String
+    { given : Maybe String
     , message : String
     }
 
@@ -26,11 +26,16 @@ type alias TestIdentifier =
     }
 
 
+type TestRunType
+    = Normal
+    | Focusing
+    | Skipping (Maybe String)
+
+
 type alias TestItem a =
     { id : TestId
     , test : a
-    , focus : Bool
-    , skipReason : Maybe String
+    , runType : TestRunType
     }
 
 
@@ -39,6 +44,7 @@ type TestResult
     | Ignore IgnoreResult
     | Pass PassResult
     | Skip SkipResult
+    | Todo TodoResult
 
 
 type alias FailResult =
@@ -55,6 +61,7 @@ type alias IgnoreResult =
 
 type alias PassResult =
     { id : TestId
+    , runType : TestRunType
     , startTime : Time
     }
 
@@ -62,4 +69,10 @@ type alias PassResult =
 type alias SkipResult =
     { id : TestId
     , reason : String
+    }
+
+
+type alias TodoResult =
+    { id : TestId
+    , messages : List FailureMessage
     }

--- a/test/integration/elm-lang/elm-lang.test.js
+++ b/test/integration/elm-lang/elm-lang.test.js
@@ -24,7 +24,7 @@ describe('elm-lang', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, 0);
+      reporterExpect(result).summaryCounts(1, 0);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-test-extra/performance/performance.test.js
+++ b/test/integration/elm-test-extra/performance/performance.test.js
@@ -29,7 +29,7 @@ describe('elm-test-extra-performance', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1000, 0, 0);
+      reporterExpect(result).summaryCounts(1000, 0, null, 0);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-test-extra/performance/performance.test.js
+++ b/test/integration/elm-test-extra/performance/performance.test.js
@@ -29,7 +29,7 @@ describe('elm-test-extra-performance', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1000, 0, null, 0);
+      reporterExpect(result).summaryCounts(1000, 0);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-test-extra/simple/fail/tests/Tests.elm
+++ b/test/integration/elm-test-extra/simple/fail/tests/Tests.elm
@@ -13,6 +13,7 @@ all =
         [ testExpectFail
         , testExpectTrue
         , testExpectFalse
+        , testExpectErr
         , testExpectEqualStringShort
         , testExpectEqualStringLong
         , testExpectEqualFloat
@@ -28,6 +29,8 @@ all =
         , testExpectEqualUnionDifferentRecordsNoCommonField
         , testExpectEqualUnionDifferentRecordsCommonField
         , testExpectNotEqual
+        , testExpectAllEmptyList
+        , testExpectAllFirstFails
         , testExpectLessThan
         , testExpectGreaterThan
         , testExpectAtLeast
@@ -64,6 +67,13 @@ testExpectFalse =
             True
                 |> Expect.false "Expected false"
 
+testExpectErr : Test
+testExpectErr =
+    test "Expect.err test" <|
+        \() ->
+            String.toInt "123"
+                |> Expect.err
+
 
 testExpectEqualStringShort : Test
 testExpectEqualStringShort =
@@ -74,7 +84,7 @@ testExpectEqualStringShort =
 
 testExpectEqualStringLong : Test
 testExpectEqualStringLong =
-    test "Expect.equal string test" <|
+    test "Expect.equal string long test" <|
         \() ->
             Expect.equal "Plan steps for world domination with tail in the air dream about hunting birds or lounge in doorway so chew foot. Chase red laser dot. Hola te quiero kick up litter or sit on human thinking longingly about tuna brine howl on top of tall thing. When in doubt, wash eat and than sleep on your face, claws in your leg stare at ceiling light yet cats making all the muffins" "Plan steps for world domination with tail in the air dream about hunting mouse or lounge in doorway so chew foot. Watch red laser dot. Hola te quiero kick up litter or sit on human thinking longingly about tuna brine howl on top of tall thing. When in doubt, wash eat and than sleep on your face, claws in your leg stare at ceiling light yet cats making all the muffins"
 
@@ -88,28 +98,28 @@ testExpectEqualFloat =
 
 testExpectEqualFloatNegative : Test
 testExpectEqualFloatNegative =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - negative and positive" <|
         \() ->
             Expect.equal -123.456 132.466
 
 
 testExpectEqualFloatExponent : Test
 testExpectEqualFloatExponent =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - exponential" <|
         \() ->
             Expect.equal 1.234e122 123
 
 
 testExpectEqualFloatNaN : Test
 testExpectEqualFloatNaN =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - NaN" <|
         \() ->
             Expect.equal 123 (sqrt -1)
 
 
 testExpectEqualFloatInfinite : Test
 testExpectEqualFloatInfinite =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - infinite" <|
         \() ->
             Expect.equal 123 (1 / 0)
 
@@ -178,6 +188,18 @@ testExpectNotEqual =
         \() ->
             Expect.notEqual "foobar" "foobar"
 
+
+testExpectAllEmptyList : Test
+testExpectAllEmptyList =
+     test "Expect.all empty test" <|
+        \() ->
+            Expect.all [] (List.length [])
+
+testExpectAllFirstFails : Test
+testExpectAllFirstFails =
+     test "Expect.all first fails test" <|
+        \() ->
+            Expect.all [Expect.equal 123, Expect.equal 456] (456)
 
 testExpectLessThan : Test
 testExpectLessThan =

--- a/test/integration/elm-test-extra/simple/only/tests/Tests.elm
+++ b/test/integration/elm-test-extra/simple/only/tests/Tests.elm
@@ -2,7 +2,7 @@ module Tests exposing (all)
 
 import Expect exposing (pass)
 import Fuzz exposing (int, list)
-import ElmTest.Extra exposing (Test, describe, only, fuzz, skip, test)
+import ElmTest.Extra exposing (Test, describe, only, fuzz, skip, test, todo)
 
 
 all : Test
@@ -12,6 +12,7 @@ all =
         , onlySuiteContainingSkipped
         , passingTest
         , onlyFuzzTest
+        , todoTest
         ]
 
 
@@ -63,3 +64,7 @@ onlyFuzzTest =
                     |> List.length
                     |> Expect.equal (List.length xs)
                     |> Debug.log "onlyFuzzTest"
+
+todoTest : Test
+todoTest =
+    todo "todoTest"

--- a/test/integration/elm-test-extra/simple/only/tests/Tests.elm
+++ b/test/integration/elm-test-extra/simple/only/tests/Tests.elm
@@ -2,31 +2,31 @@ module Tests exposing (all)
 
 import Expect exposing (pass)
 import Fuzz exposing (int, list)
-import ElmTest.Extra exposing (Test, describe, focus, fuzz, skip, test)
+import ElmTest.Extra exposing (Test, describe, only, fuzz, skip, test)
 
 
 all : Test
 all =
-    describe "focusTestSuite"
-        [ focusTest
-        , focusSuiteContainingSkipped
+    describe "onlyTestSuite"
+        [ onlyTest
+        , onlySuiteContainingSkipped
         , passingTest
-        , focusFuzzTest
+        , onlyFuzzTest
         ]
 
 
-focusTest : Test
-focusTest =
-    focus <|
-        test "focusTest" <|
+onlyTest : Test
+onlyTest =
+    only <|
+        test "onlyTest" <|
             \() ->
                 Expect.pass
 
 
-focusSuiteContainingSkipped : Test
-focusSuiteContainingSkipped =
-    focus <|
-        describe "focusSuite"
+onlySuiteContainingSkipped : Test
+onlySuiteContainingSkipped =
+    only <|
+        describe "onlySuite"
             [ normalTest
             , skippedTest
             ]
@@ -54,12 +54,12 @@ passingTest =
             Expect.fail "Never runs"
 
 
-focusFuzzTest : Test
-focusFuzzTest =
-    focus <|
-        fuzz (list int) "focusFuzzTest" <|
+onlyFuzzTest : Test
+onlyFuzzTest =
+    only <|
+        fuzz (list int) "onlyFuzzTest" <|
             \xs ->
                 List.sort xs
                     |> List.length
                     |> Expect.equal (List.length xs)
-                    |> Debug.log "focusFuzzTest"
+                    |> Debug.log "onlyFuzzTest"

--- a/test/integration/elm-test-extra/simple/simple.test.js
+++ b/test/integration/elm-test-extra/simple/simple.test.js
@@ -29,7 +29,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, 0);
+      reporterExpect(result).summaryCounts(1, 0, null, 0);
       expect(result.code).to.equal(0);
     });
   });
@@ -50,7 +50,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryFailed();
-      reporterExpect(result).summaryCounts(0, 29, 0);
+      reporterExpect(result).summaryCounts(0, 32, null, 0);
       expect(result.code).to.equal(1);
     });
 
@@ -109,7 +109,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, 0);
+      reporterExpect(result).summaryCounts(4, 0, null, 0);
       expect(result.code).to.equal(0);
     });
 
@@ -122,7 +122,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, 0);
+      reporterExpect(result).summaryCounts(4, 0, null, 0);
       reporterExpect(result).summaryArgument('runCount', expectedRunCount);
 
       expect(result.stdout.match(/fuzzingTest-Executed/g).length).to.equal(expectedRunCount);
@@ -144,7 +144,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, 0);
+      reporterExpect(result).summaryCounts(4, 0, null, 0);
       reporterExpect(result).summaryArgument('seed', initialSeed);
       expect(result.code).to.equal(0);
     });
@@ -166,7 +166,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, 0);
+      reporterExpect(result).summaryCounts(1, 0, null, 0);
       expect(result.code).to.equal(0);
     });
   });
@@ -187,16 +187,16 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryFailed();
-      reporterExpect(result).summaryCounts(5, 2, 0);
+      reporterExpect(result).summaryCounts(5, 2, null, 0);
       expect(result.stdout).to.matches(/Tests(.|\n)+SecondChildTest\n.+failingTest - Child/);
       expect(result.stdout).to.matches(/Tests(.|\n)+FailingGrandChildTest\n.+failingTest - GrandChild/);
       expect(result.code).to.equal(1);
     });
   });
 
-  describe('focus', function() {
+  describe('only', function() {
     beforeEach(function() {
-      runner.contextPush(testContext, 'focus');
+      runner.contextPush(testContext, 'only');
       runner.clean();
     });
 
@@ -211,7 +211,7 @@ describe('elm-test-extra-simple', function() {
       // assert
       reporterExpect(result).summaryFocused();
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(3, 0, 0, 2);
+      reporterExpect(result).summaryCounts(3, 0, null, 0, 2);
       expect(result.code).to.equal(0);
     });
   });
@@ -232,7 +232,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryInconclusive();
-      reporterExpect(result).summaryCounts(1, 0, 4);
+      reporterExpect(result).summaryCounts(1, 0, null, 4);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-test-extra/simple/simple.test.js
+++ b/test/integration/elm-test-extra/simple/simple.test.js
@@ -29,7 +29,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, null, 0);
+      reporterExpect(result).summaryCounts(1, 0);
       expect(result.code).to.equal(0);
     });
   });
@@ -50,7 +50,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryFailed();
-      reporterExpect(result).summaryCounts(0, 32, null, 0);
+      reporterExpect(result).summaryCounts(0, 32);
       expect(result.code).to.equal(1);
     });
 
@@ -109,7 +109,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, null, 0);
+      reporterExpect(result).summaryCounts(4, 0);
       expect(result.code).to.equal(0);
     });
 
@@ -122,7 +122,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, null, 0);
+      reporterExpect(result).summaryCounts(4, 0);
       reporterExpect(result).summaryArgument('runCount', expectedRunCount);
 
       expect(result.stdout.match(/fuzzingTest-Executed/g).length).to.equal(expectedRunCount);
@@ -144,7 +144,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, null, 0);
+      reporterExpect(result).summaryCounts(4, 0);
       reporterExpect(result).summaryArgument('seed', initialSeed);
       expect(result.code).to.equal(0);
     });
@@ -166,7 +166,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, null, 0);
+      reporterExpect(result).summaryCounts(1, 0);
       expect(result.code).to.equal(0);
     });
   });
@@ -187,7 +187,7 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryFailed();
-      reporterExpect(result).summaryCounts(5, 2, null, 0);
+      reporterExpect(result).summaryCounts(5, 2);
       expect(result.stdout).to.matches(/Tests(.|\n)+SecondChildTest\n.+failingTest - Child/);
       expect(result.stdout).to.matches(/Tests(.|\n)+FailingGrandChildTest\n.+failingTest - GrandChild/);
       expect(result.code).to.equal(1);
@@ -211,7 +211,7 @@ describe('elm-test-extra-simple', function() {
       // assert
       reporterExpect(result).summaryFocused();
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(3, 0, null, 0, 2);
+      reporterExpect(result).summaryCounts(3, 0, null, null, 3);
       expect(result.code).to.equal(0);
     });
   });
@@ -232,7 +232,28 @@ describe('elm-test-extra-simple', function() {
 
       // assert
       reporterExpect(result).summaryInconclusive();
-      reporterExpect(result).summaryCounts(1, 0, null, 4);
+      reporterExpect(result).summaryCounts(1, 0, null, 5);
+      expect(result.code).to.equal(0);
+    });
+  });
+
+  describe('todo', function() {
+    beforeEach(function() {
+      runner.contextPush(testContext, 'todo');
+      runner.clean();
+    });
+
+    afterEach(function() {
+      runner.contextPop(testContext);
+    });
+
+    it('should report inconclusive', function() {
+      // act
+      var result = runner.run(testContext, 'elm-test-extra');
+
+      // assert
+      reporterExpect(result).summaryInconclusive();
+      reporterExpect(result).summaryCounts(1, 0, 1);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-test-extra/simple/skip/tests/Tests.elm
+++ b/test/integration/elm-test-extra/simple/skip/tests/Tests.elm
@@ -2,7 +2,7 @@ module Tests exposing (all)
 
 import Expect exposing (pass)
 import Fuzz exposing (int, list)
-import ElmTest.Extra exposing (Test, describe, fuzz, only, skip, test)
+import ElmTest.Extra exposing (Test, describe, fuzz, only, skip, test, todo)
 
 
 all : Test
@@ -12,6 +12,7 @@ all =
         , skippedSuiteContainingFocus
         , passingTest
         , skipFuzzTest
+        , skipTodoTest
         ]
 
 
@@ -60,3 +61,8 @@ skipFuzzTest =
         fuzz (list int) "focusFuzzTest" <|
             \xs ->
                 Expect.fail "Never runs"
+
+
+skipTodoTest : Test
+skipTodoTest =
+    skip "skip todo test" <| todo "todoTest"

--- a/test/integration/elm-test-extra/simple/todo/tests/Tests.elm
+++ b/test/integration/elm-test-extra/simple/todo/tests/Tests.elm
@@ -1,7 +1,7 @@
 module Tests exposing (all)
 
 import Expect exposing (pass)
-import Test exposing (Test, describe, test, todo)
+import ElmTest.Extra exposing (Test, describe, test, todo, only, skip)
 
 
 all : Test

--- a/test/integration/elm-test-extra/simple/todo/tests/Tests.elm
+++ b/test/integration/elm-test-extra/simple/todo/tests/Tests.elm
@@ -1,0 +1,24 @@
+module Tests exposing (all)
+
+import Expect exposing (pass)
+import Test exposing (Test, describe, test, todo)
+
+
+all : Test
+all =
+    describe "todoTestSuite"
+        [ todoTest
+        , passingTest
+        ]
+
+
+todoTest : Test
+todoTest =
+    todo "todoTest"
+
+
+passingTest : Test
+passingTest =
+    test "passingTest" <|
+        \() ->
+            Expect.pass

--- a/test/integration/elm-test/performance/performance.test.js
+++ b/test/integration/elm-test/performance/performance.test.js
@@ -29,7 +29,7 @@ describe('elm-test-performance', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1000, 0, 0);
+      reporterExpect(result).summaryCounts(1000, 0);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-test/simple/fail/tests/Tests.elm
+++ b/test/integration/elm-test/simple/fail/tests/Tests.elm
@@ -4,7 +4,7 @@ import Dict
 import Expect exposing (atLeast, atMost, equal, fail, false, greaterThan, notEqual, true)
 import Fuzz exposing (string)
 import Set
-import Test exposing (Test, describe, fuzz, fuzzWith, fuzz2, test)
+import Test exposing (Test, describe, fuzz, fuzzWith, fuzz2, skip, test)
 
 
 all : Test
@@ -13,6 +13,7 @@ all =
         [ testExpectFail
         , testExpectTrue
         , testExpectFalse
+        , testExpectErr
         , testExpectEqualStringShort
         , testExpectEqualStringLong
         , testExpectEqualFloat
@@ -28,6 +29,8 @@ all =
         , testExpectEqualUnionDifferentRecordsNoCommonField
         , testExpectEqualUnionDifferentRecordsCommonField
         , testExpectNotEqual
+        , testExpectAllEmptyList
+        , testExpectAllFirstFails
         , testExpectLessThan
         , testExpectGreaterThan
         , testExpectAtLeast
@@ -64,6 +67,13 @@ testExpectFalse =
             True
                 |> Expect.false "Expected false"
 
+testExpectErr : Test
+testExpectErr =
+    test "Expect.err test" <|
+        \() ->
+            String.toInt "123"
+                |> Expect.err
+
 
 testExpectEqualStringShort : Test
 testExpectEqualStringShort =
@@ -74,7 +84,7 @@ testExpectEqualStringShort =
 
 testExpectEqualStringLong : Test
 testExpectEqualStringLong =
-    test "Expect.equal string test" <|
+    test "Expect.equal string long test" <|
         \() ->
             Expect.equal "Plan steps for world domination with tail in the air dream about hunting birds or lounge in doorway so chew foot. Chase red laser dot. Hola te quiero kick up litter or sit on human thinking longingly about tuna brine howl on top of tall thing. When in doubt, wash eat and than sleep on your face, claws in your leg stare at ceiling light yet cats making all the muffins" "Plan steps for world domination with tail in the air dream about hunting mouse or lounge in doorway so chew foot. Watch red laser dot. Hola te quiero kick up litter or sit on human thinking longingly about tuna brine howl on top of tall thing. When in doubt, wash eat and than sleep on your face, claws in your leg stare at ceiling light yet cats making all the muffins"
 
@@ -88,28 +98,28 @@ testExpectEqualFloat =
 
 testExpectEqualFloatNegative : Test
 testExpectEqualFloatNegative =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - negative and positive" <|
         \() ->
             Expect.equal -123.456 132.466
 
 
 testExpectEqualFloatExponent : Test
 testExpectEqualFloatExponent =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - exponential" <|
         \() ->
             Expect.equal 1.234e122 123
 
 
 testExpectEqualFloatNaN : Test
 testExpectEqualFloatNaN =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - NaN" <|
         \() ->
             Expect.equal 123 (sqrt -1)
 
 
 testExpectEqualFloatInfinite : Test
 testExpectEqualFloatInfinite =
-    test "Expect.equal float test" <|
+    test "Expect.equal float test - infinite" <|
         \() ->
             Expect.equal 123 (1 / 0)
 
@@ -178,6 +188,18 @@ testExpectNotEqual =
         \() ->
             Expect.notEqual "foobar" "foobar"
 
+
+testExpectAllEmptyList : Test
+testExpectAllEmptyList =
+     skip <| test "Expect.all empty test" <|
+        \() ->
+            Expect.all [] (List.length [])
+
+testExpectAllFirstFails : Test
+testExpectAllFirstFails =
+     test "Expect.all first fails test" <|
+        \() ->
+            Expect.all [Expect.equal 123, Expect.equal 456] (456)
 
 testExpectLessThan : Test
 testExpectLessThan =

--- a/test/integration/elm-test/simple/only/tests/Tests.elm
+++ b/test/integration/elm-test/simple/only/tests/Tests.elm
@@ -2,7 +2,7 @@ module Tests exposing (all)
 
 import Expect exposing (pass)
 import Fuzz exposing (int, list)
-import Test exposing (Test, describe, fuzz, only, skip, test)
+import Test exposing (Test, describe, fuzz, only, skip, test, todo)
 
 
 all : Test
@@ -12,6 +12,7 @@ all =
         , onlySuiteContainingSkipped
         , passingTest
         , onlyFuzzTest
+        , todoTest
         ]
 
 
@@ -63,3 +64,8 @@ onlyFuzzTest =
                     |> List.length
                     |> Expect.equal (List.length xs)
                     |> Debug.log "onlyFuzzTest"
+
+
+todoTest : Test
+todoTest =
+    todo "todoTest"

--- a/test/integration/elm-test/simple/only/tests/Tests.elm
+++ b/test/integration/elm-test/simple/only/tests/Tests.elm
@@ -1,0 +1,65 @@
+module Tests exposing (all)
+
+import Expect exposing (pass)
+import Fuzz exposing (int, list)
+import Test exposing (Test, describe, fuzz, only, skip, test)
+
+
+all : Test
+all =
+    describe "onlyTestSuite"
+        [ onlyTest
+        , onlySuiteContainingSkipped
+        , passingTest
+        , onlyFuzzTest
+        ]
+
+
+onlyTest : Test
+onlyTest =
+    only <|
+        test "onlyTest" <|
+            \() ->
+                Expect.pass
+
+
+onlySuiteContainingSkipped : Test
+onlySuiteContainingSkipped =
+    only <|
+        describe "onlySuite"
+            [ normalTest
+            , skippedTest
+            ]
+
+
+normalTest : Test
+normalTest =
+    test "normalTest" <|
+        \() ->
+            Expect.pass
+
+
+skippedTest : Test
+skippedTest =
+    skip <|
+        test "skippedTest" <|
+            \() ->
+                Expect.fail "Never runs"
+
+
+passingTest : Test
+passingTest =
+    test "passingTest" <|
+        \() ->
+            Expect.fail "Never runs"
+
+
+onlyFuzzTest : Test
+onlyFuzzTest =
+    only <|
+        fuzz (list int) "onlyFuzzTest" <|
+            \xs ->
+                List.sort xs
+                    |> List.length
+                    |> Expect.equal (List.length xs)
+                    |> Debug.log "onlyFuzzTest"

--- a/test/integration/elm-test/simple/simple.test.js
+++ b/test/integration/elm-test/simple/simple.test.js
@@ -29,7 +29,7 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, 0);
+      reporterExpect(result).summaryCounts(1, 0);
       expect(result.code).to.equal(0);
     });
   });
@@ -50,7 +50,7 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryFailed();
-      reporterExpect(result).summaryCounts(0, 29, 0);
+      reporterExpect(result).summaryCounts(0, 31);
       expect(result.code).to.equal(1);
     });
 
@@ -109,7 +109,7 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, 0);
+      reporterExpect(result).summaryCounts(4, 0);
       expect(result.code).to.equal(0);
     });
 
@@ -122,7 +122,7 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, 0);
+      reporterExpect(result).summaryCounts(4, 0);
       reporterExpect(result).summaryArgument('runCount', expectedRunCount);
 
       expect(result.stdout.match(/fuzzingTest-Executed/g).length).to.equal(expectedRunCount);
@@ -144,7 +144,7 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(4, 0, 0);
+      reporterExpect(result).summaryCounts(4, 0);
       reporterExpect(result).summaryArgument('seed', initialSeed);
       expect(result.code).to.equal(0);
     });
@@ -166,7 +166,7 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0, 0);
+      reporterExpect(result).summaryCounts(1, 0);
       expect(result.code).to.equal(0);
     });
   });
@@ -187,11 +187,76 @@ describe('elm-test-simple', function() {
 
       // assert
       reporterExpect(result).summaryFailed();
-      reporterExpect(result).summaryCounts(6, 3, 0);
+      reporterExpect(result).summaryCounts(6, 3);
       expect(result.stdout).to.matches(/Tests\n.+failingTest - Concat/);
       expect(result.stdout).to.matches(/Tests(.|\n)+SecondChildTest\n.+failingTest - Child/);
       expect(result.stdout).to.matches(/Tests(.|\n)+FailingGrandChildTest\n.+failingTest - GrandChild/);
       expect(result.code).to.equal(1);
+    });
+  });
+
+  describe('only', function() {
+    beforeEach(function() {
+      runner.contextPush(testContext, 'only');
+      runner.clean();
+    });
+
+    afterEach(function() {
+      runner.contextPop(testContext);
+    });
+
+    it('should report only passed', function() {
+      // act
+      var result = runner.run(testContext, 'elm-test', '--runCount=5');
+
+      // assert
+      reporterExpect(result).summaryPartial();
+      reporterExpect(result).summaryPassed();
+      reporterExpect(result).summaryCounts(3, 0);
+      expect(result.code).to.equal(0);
+    });
+  });
+
+  describe('skip', function() {
+    beforeEach(function() {
+      runner.contextPush(testContext, 'skip');
+      runner.clean();
+    });
+
+    afterEach(function() {
+      runner.contextPop(testContext);
+    });
+
+    it('should report inconclusive', function() {
+      // act
+      var result = runner.run(testContext, 'elm-test');
+
+      // assert
+      reporterExpect(result).summaryPartial();
+      reporterExpect(result).summaryInconclusive();
+      reporterExpect(result).summaryCounts(1, 0);
+      expect(result.code).to.equal(0);
+    });
+  });
+
+  describe('todo', function() {
+    beforeEach(function() {
+      runner.contextPush(testContext, 'todo');
+      runner.clean();
+    });
+
+    afterEach(function() {
+      runner.contextPop(testContext);
+    });
+
+    it('should report inconclusive', function() {
+      // act
+      var result = runner.run(testContext, 'elm-test');
+
+      // assert
+      reporterExpect(result).summaryInconclusive();
+      reporterExpect(result).summaryCounts(1, 0, 1);
+      expect(result.code).to.equal(0);
     });
   });
 });

--- a/test/integration/elm-test/simple/skip/tests/Tests.elm
+++ b/test/integration/elm-test/simple/skip/tests/Tests.elm
@@ -2,7 +2,7 @@ module Tests exposing (all)
 
 import Expect exposing (pass)
 import Fuzz exposing (int, list)
-import Test exposing (Test, describe, fuzz, only, skip, test)
+import Test exposing (Test, describe, fuzz, only, skip, test, todo)
 
 
 all : Test
@@ -12,6 +12,7 @@ all =
         , skippedSuiteContainingFocus
         , passingTest
         , skipFuzzTest
+        , skipTodoTest
         ]
 
 
@@ -60,3 +61,8 @@ skipFuzzTest =
         fuzz (list int) "focusFuzzTest" <|
             \xs ->
                 Expect.fail "Never runs"
+
+
+skipTodoTest : Test
+skipTodoTest =
+    skip <| todo "todoTest"

--- a/test/integration/elm-test/simple/skip/tests/Tests.elm
+++ b/test/integration/elm-test/simple/skip/tests/Tests.elm
@@ -2,7 +2,7 @@ module Tests exposing (all)
 
 import Expect exposing (pass)
 import Fuzz exposing (int, list)
-import ElmTest.Extra exposing (Test, describe, fuzz, only, skip, test)
+import Test exposing (Test, describe, fuzz, only, skip, test)
 
 
 all : Test
@@ -17,7 +17,7 @@ all =
 
 skippedTest : Test
 skippedTest =
-    skip "ignore test" <|
+    skip <|
         test "skippedTest" <|
             \() ->
                 Expect.fail "Never runs"
@@ -25,10 +25,10 @@ skippedTest =
 
 skippedSuiteContainingFocus : Test
 skippedSuiteContainingFocus =
-    skip "ignore suite" <|
+    skip <|
         describe "skippedSuite"
             [ normalTest
-            , onlyTest
+            , focusTest
             ]
 
 
@@ -39,10 +39,10 @@ normalTest =
             Expect.fail "Never runs"
 
 
-onlyTest : Test
-onlyTest =
+focusTest : Test
+focusTest =
     only <|
-        test "onlyTest" <|
+        test "focusTest" <|
             \() ->
                 Expect.fail "Never runs"
 
@@ -56,7 +56,7 @@ passingTest =
 
 skipFuzzTest : Test
 skipFuzzTest =
-    skip "ignore test" <|
+    skip <|
         fuzz (list int) "focusFuzzTest" <|
             \xs ->
                 Expect.fail "Never runs"

--- a/test/integration/elm-test/simple/todo/tests/Tests.elm
+++ b/test/integration/elm-test/simple/todo/tests/Tests.elm
@@ -1,0 +1,24 @@
+module Tests exposing (all)
+
+import Expect exposing (pass)
+import Test exposing (Test, describe, test, todo)
+
+
+all : Test
+all =
+    describe "todoTestSuite"
+        [ todoTest
+        , passingTest
+        ]
+
+
+todoTest : Test
+todoTest =
+    todo "todoTest"
+
+
+passingTest : Test
+passingTest =
+    test "passingTest" <|
+        \() ->
+            Expect.pass

--- a/test/integration/elm-test/simple/tree/tests/ConcatChildTest.elm
+++ b/test/integration/elm-test/simple/tree/tests/ConcatChildTest.elm
@@ -1,8 +1,6 @@
 module ConcatChildTest exposing (all)
 
 import Expect exposing (pass)
-import FailingGrandChildTest exposing (all)
-import PassingGrandChildTest exposing (all)
 import Test exposing (Test, concat, test)
 
 

--- a/test/integration/lib/default-reporter-expect.js
+++ b/test/integration/lib/default-reporter-expect.js
@@ -7,13 +7,26 @@ function summaryArgument(result, argName, argValue) {
   expect(result.stdout).to.match(new RegExp(argName + ':\\s+' + argValue));
 }
 
-function summaryCounts(result, pass, fail, skip, ignore) {
+function summaryCounts(result, pass, fail, todo, skip, ignore) {
   expect(result.stdout).to.match(new RegExp('Passed:\\s+' + pass + '\n'));
   expect(result.stdout).to.match(new RegExp('Failed:\\s+' + fail + '\n'));
-  expect(result.stdout).to.match(new RegExp('Skipped:\\s+' + skip + '\n'));
 
-  if (ignore) {
+  if(todo || todo === 0) {
+    expect(result.stdout).to.match(new RegExp('Todo:\\s+' + todo + '\n'));
+  } else {
+    expect(result.stdout).not.to.match(new RegExp('Todo:\\s+'));
+  }
+
+  if(skip || skip === 0) {
+    expect(result.stdout).to.match(new RegExp('Skipped:\\s+' + skip + '\n'));
+  } else {
+    expect(result.stdout).not.to.match(new RegExp('Skipped:\\s+'));
+  }
+
+  if (ignore || ignore === 0) {
     expect(result.stdout).to.match(new RegExp('Ignored:\\s+' + ignore + '\n'));
+  } else {
+    expect(result.stdout).not.to.match(new RegExp('Ignored:\\s+'));
   }
 }
 
@@ -29,6 +42,10 @@ function summaryInconclusive(result) {
   expect(result.stdout).to.match(/TEST RUN INCONCLUSIVE/);
 }
 
+function summaryPartial(result) {
+  expect(result.stdout).to.match(/PARTIAL TEST RUN/);
+}
+
 function summaryPassed(result) {
   expect(result.stdout).to.match(/TEST RUN PASSED/);
 }
@@ -40,6 +57,7 @@ module.exports = function(result) {
     summaryFocused: _.wrap(result, summaryFocused),
     summaryCounts: _.wrap(result, summaryCounts),
     summaryInconclusive: _.wrap(result, summaryInconclusive),
+    summaryPartial: _.wrap(result, summaryPartial),
     summaryPassed: _.wrap(result, summaryPassed)
   };
 };

--- a/test/unit/plugin/default-reporter/reporter-plugin.test.js
+++ b/test/unit/plugin/default-reporter/reporter-plugin.test.js
@@ -30,6 +30,8 @@ describe('plugin default-reporter reporter-plugin', function() {
       output = '';
       original = process.stdout.write;
       process.stdout.write = write;
+
+      reporter.init(0);
     });
 
     afterEach(function() {
@@ -57,7 +59,7 @@ describe('plugin default-reporter reporter-plugin', function() {
       reporter.update('SKIPPED');
 
       // assert
-      expect(output).to.equal(chalk.yellow('?'));
+      expect(output).to.equal(chalk.yellow.dim('?'));
     });
 
     it('should report " " when a test has unknown result', function() {

--- a/test/unit/plugin/default-reporter/reporter-plugin.test.js
+++ b/test/unit/plugin/default-reporter/reporter-plugin.test.js
@@ -59,7 +59,7 @@ describe('plugin default-reporter reporter-plugin', function() {
       reporter.update('SKIPPED');
 
       // assert
-      expect(output).to.equal(chalk.yellow.dim('?'));
+      expect(output).to.equal(chalk.yellow('?'));
     });
 
     it('should report " " when a test has unknown result', function() {


### PR DESCRIPTION
Adds support for todo, renames focus -> only
Adds —failOnSkip, —failOnTodo, —showTodo