### PR TITLE
Improve debug logging

### DIFF
--- a/.idea/runConfigurations/Integration___All.xml
+++ b/.idea/runConfigurations/Integration___All.xml
@@ -10,7 +10,7 @@
       <env name="noisyTestRun" value="true" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--compilers ts:ts-node/register --timeout 100000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register --timeout 100000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>**/*.test.ts</test-pattern>
     <method />

--- a/.idea/runConfigurations/Integration___elm_test_extra_simple.xml
+++ b/.idea/runConfigurations/Integration___elm_test_extra_simple.xml
@@ -10,7 +10,7 @@
       <env name="noisyTestRun" value="true" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--compilers ts:ts-node/register --timeout 100000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register --timeout 100000</extra-mocha-options>
     <test-kind>SUITE</test-kind>
     <test-file>$PROJECT_DIR$/test/integration/elm-test-extra/simple.test.ts</test-file>
     <test-names>

--- a/.idea/runConfigurations/Integration___elm_test_simple.xml
+++ b/.idea/runConfigurations/Integration___elm_test_simple.xml
@@ -10,7 +10,7 @@
       <env name="noisyTestRun" value="true" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--compilers ts:ts-node/register --timeout 100000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register --timeout 100000</extra-mocha-options>
     <test-kind>SUITE</test-kind>
     <test-file>$PROJECT_DIR$/test/integration/elm-test/simple.test.ts</test-file>
     <test-names>

--- a/.idea/runConfigurations/Unit___Mocha.xml
+++ b/.idea/runConfigurations/Unit___Mocha.xml
@@ -6,7 +6,7 @@
     <pass-parent-env>true</pass-parent-env>
     <envs />
     <ui>tdd</ui>
-    <extra-mocha-options>--compilers ts:ts-node/register</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>**/*.test.ts</test-pattern>
     <method />

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ assertion it adds a visual hint for the source of the difference:
 </p>
  
 The following options are supported by the default reporter:
+* hideDebugMessages - prevent reporting of any test Debug.log messages
 * showSkip - report skipped tests and the reasons after the summary.
 This option is only available with elm-test-extra and is ignored when
 the quiet option is present

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -152,6 +152,7 @@ export interface TestReportTodoLeaf extends TestReportNode, TestReportTimed {
 
 export interface TestResultDecorator {
   bulletPoint(): string;
+  debugLog(value: string): string;
   diff(value: string): string;
   expect(value: string): string;
   failed(value: string): string;
@@ -160,6 +161,7 @@ export interface TestResultDecorator {
   inconclusive(value: string): string;
   only(value: string): string;
   passed(value: string): string;
+  rightArrow(): string;
   skip(value: string): string;
   todo(value: string): string;
   verticalBarEnd(): string;

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -98,8 +98,13 @@ export interface TestArgs {
 }
 
 export interface TestReportNode {
+  readonly id: number;
   readonly label: string;
   readonly resultType: ResultType;
+}
+
+export interface TestReportLogged {
+  readonly logMessages: string[];
 }
 
 export interface TestReportTimed {
@@ -113,14 +118,15 @@ export interface TestReportConfig {
   readonly runCount: number;
 }
 
-export interface TestReportFailedLeaf extends TestReportNode, TestReportTimed {
-  readonly resultMessages: FailureMessage[];
+export interface TestReportFailedLeaf extends TestReportNode, TestReportLogged, TestReportTimed {
+    readonly resultMessages: FailureMessage[];
 }
 
 export interface TestReportIgnoredLeaf extends TestReportNode {
 }
 
-export interface TestReportPassedLeaf extends TestReportNode, TestReportTimed {
+export interface TestReportPassedLeaf extends TestReportNode, TestReportLogged, TestReportTimed {
+  readonly logMessages: string[];
 }
 
 export interface TestReportSkippedLeaf extends TestReportNode {
@@ -193,6 +199,7 @@ export interface TestRunSummary {
   readonly skippedCount: number;
   readonly startDateTime: Date | undefined;
   readonly success: boolean;
+  readonly successes: TestRunLeaf<TestReportPassedLeaf>[];
   readonly todo: TestRunLeaf<TestReportTodoLeaf>[];
   readonly todoCount: number;
 }

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -44,6 +44,7 @@ export class RunnerImp {
         stdout.write = RunnerImp.testRunStdOutWrite;
         RunnerImp.debugLogMessages = [];
       } catch (err) {
+        stdout.write = RunnerImp.originalNodeProcessWrite;
         reject(err);
       }
     };
@@ -59,6 +60,7 @@ export class RunnerImp {
         stdout.write = RunnerImp.testRunStdOutWrite;
         RunnerImp.debugLogMessages = [];
       } catch (err) {
+        stdout.write = RunnerImp.originalNodeProcessWrite;
         reject(err);
       }
     };
@@ -69,8 +71,12 @@ export class RunnerImp {
     return (rawResults: TestReportRoot) => {
       stdout.write = RunnerImp.originalNodeProcessWrite;
       logger.trace("Test run complete", rawResults);
-      let promise = reporter.finish(rawResults);
-      promise.then(() => resolve()).catch(err => reject(err));
+      reporter.finish(rawResults)
+        .then(() => resolve())
+        .catch((err) => {
+          stdout.write = RunnerImp.originalNodeProcessWrite;
+          reject(err);
+        });
     };
   }
 

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -3,7 +3,6 @@ import {createLogger, Logger} from "./logger";
 import {createReporter, Reporter} from "./reporter";
 import {LoboConfig, ProgressReport, Reject, Resolve, RunArgs, TestReportRoot} from "./plugin";
 
-
 export interface LoboElmApp {
   ports: {
     begin: { subscribe: (args: (testCount: number) => void) => void },
@@ -21,41 +20,64 @@ export interface Runner {
   run(config: LoboConfig): Bluebird<object>;
 }
 
+export type NodeProcessWrite = (str: string, encoding?: string, cb?: Function) => boolean;
+
+export interface NodeProcessStdout {
+  write: NodeProcessWrite;
+}
+
 export class RunnerImp {
+
+  public static originalNodeProcessWrite: NodeProcessWrite;
+  public static debugLogMessages: string[];
 
   private logger: Logger;
   private reporter: Reporter;
 
-  public static makeTestRunBegin(logger: Logger, reporter: Reporter, reject: Reject): (testCount: number) => void {
+  public static makeTestRunBegin(stdout: NodeProcessStdout, logger: Logger, reporter: Reporter, reject: Reject):
+  (testCount: number) => void {
     return (testCount: number) => {
       try {
         logger.debug("Test run beginning", <{}>testCount);
         reporter.init(testCount);
+        RunnerImp.originalNodeProcessWrite = stdout.write;
+        stdout.write = RunnerImp.testRunStdOutWrite;
+        RunnerImp.debugLogMessages = [];
       } catch (err) {
         reject(err);
       }
     };
   }
 
-  public static makeTestRunProgress(logger: Logger, reporter: Reporter, reject: Reject):
+  public static makeTestRunProgress(stdout: NodeProcessStdout, logger: Logger, reporter: Reporter, reject: Reject):
   (result: ProgressReport) => void {
     return (result: ProgressReport) => {
       try {
-        reporter.update(result);
-        logger.trace("Test run progress", result);
+        stdout.write = RunnerImp.originalNodeProcessWrite;
+        reporter.update(result, RunnerImp.debugLogMessages);
+        logger.trace("Test run progress", { result: result, debugLogMessages: RunnerImp.debugLogMessages});
+        stdout.write = RunnerImp.testRunStdOutWrite;
+        RunnerImp.debugLogMessages = [];
       } catch (err) {
         reject(err);
       }
     };
   }
 
-  public static makeTestRunComplete(logger: Logger, reporter: Reporter, resolve: Resolve, reject: Reject):
+  public static makeTestRunComplete(stdout: NodeProcessStdout, logger: Logger, reporter: Reporter, resolve: Resolve, reject: Reject):
   (rawResults: TestReportRoot) => void {
     return (rawResults: TestReportRoot) => {
+      stdout.write = RunnerImp.originalNodeProcessWrite;
       logger.trace("Test run complete", rawResults);
       let promise = reporter.finish(rawResults);
       promise.then(() => resolve()).catch(err => reject(err));
     };
+  }
+
+  public static testRunStdOutWrite(str: string): boolean {
+    RunnerImp.debugLogMessages.push(str);
+
+    return true;
   }
 
   constructor(logger: Logger, reporter: Reporter) {
@@ -96,9 +118,9 @@ export class RunnerImp {
       let app = elmApp.UnitTest.worker(initArgs);
 
       logger.debug("Subscribing to ports");
-      app.ports.begin.subscribe(RunnerImp.makeTestRunBegin(logger, reporter, reject));
-      app.ports.end.subscribe(RunnerImp.makeTestRunComplete(logger, reporter, resolve, reject));
-      app.ports.progress.subscribe(RunnerImp.makeTestRunProgress(logger, reporter, reject));
+      app.ports.begin.subscribe(RunnerImp.makeTestRunBegin(process.stdout, logger, reporter, reject));
+      app.ports.end.subscribe(RunnerImp.makeTestRunComplete(process.stdout, logger, reporter, resolve, reject));
+      app.ports.progress.subscribe(RunnerImp.makeTestRunProgress(process.stdout, logger, reporter, reject));
 
       logger.debug("Running tests");
       app.ports.runTests.send({

--- a/lib/test-result-decorator-console.ts
+++ b/lib/test-result-decorator-console.ts
@@ -18,6 +18,10 @@ export class TestResultDecoratorConsoleImp implements plugin.TestResultDecorator
     return "•";
   }
 
+  public debugLog(value: string): string {
+    return chalk.cyan(value);
+  }
+
   public diff(value: string): string {
     return chalk.red(value);
   }
@@ -44,6 +48,10 @@ export class TestResultDecoratorConsoleImp implements plugin.TestResultDecorator
 
   public passed(value: string): string {
     return chalk.green(value);
+  }
+
+  public rightArrow(): string {
+    return "→";
   }
 
   public verticalBarEnd(): string {

--- a/lib/test-result-decorator-html.ts
+++ b/lib/test-result-decorator-html.ts
@@ -17,6 +17,10 @@ export class TestResultDecoratorHtmlImp implements plugin.TestResultDecorator {
     return "&bullet;";
   }
 
+  public debugLog(value: string): string {
+    return `<span style="color:darkcyan">${value}</span>`;
+  }
+
   public diff(value: string): string {
     return `<span style="color:red">${value}</span>`;
   }
@@ -43,6 +47,10 @@ export class TestResultDecoratorHtmlImp implements plugin.TestResultDecorator {
 
   public passed(value: string): string {
     return `<span style="color:green">${value}</span>`;
+  }
+
+  public rightArrow(): string {
+    return "&rarr;";
   }
 
   public verticalBarEnd(): string {

--- a/lib/test-result-decorator-text.ts
+++ b/lib/test-result-decorator-text.ts
@@ -17,6 +17,10 @@ export class TestResultDecoratorTextImp implements plugin.TestResultDecorator {
     return "•";
   }
 
+  public debugLog(value: string): string {
+    return value;
+  }
+
   public diff(value: string): string {
     return value;
   }
@@ -43,6 +47,10 @@ export class TestResultDecoratorTextImp implements plugin.TestResultDecorator {
 
   public passed(value: string): string {
     return value;
+  }
+
+  public rightArrow(): string {
+    return "→";
   }
 
   public verticalBarEnd(): string {

--- a/lib/test-result-formatter.ts
+++ b/lib/test-result-formatter.ts
@@ -6,7 +6,8 @@ import * as os from "os";
 
 export interface TestResultFormatter {
   defaultIndentation(): string;
-  formatFailure(report: plugin.TestReportFailedLeaf, padding: string, maxLength?: number): string;
+  formatDebugLogMessages(report: plugin.TestReportLogged, padding: string): string;
+  formatFailure(report: plugin.TestReportFailedLeaf, padding: string, maxLength: number): string;
   formatNotRun(report: plugin.TestReportSkippedLeaf, padding: string): string;
   formatUpdate(report: plugin.ProgressReport): string;
 }
@@ -29,6 +30,22 @@ export class TestResultFormatterImp implements TestResultFormatter {
     return "  ";
   }
 
+  public formatDebugLogMessages(report: plugin.TestReportLogged, padding: string): string {
+    if (!report.logMessages || report.logMessages.length === 0) {
+      return "";
+    }
+
+    let output: string = "";
+
+    if (report.logMessages && report.logMessages.length > 0) {
+      _.forEach(report.logMessages, (logMessage: string) => {
+        output += `${padding}${this.decorator.rightArrow()} ${this.decorator.debugLog(logMessage)}${os.EOL}`;
+      });
+    }
+
+    return output + os.EOL;
+  }
+
   public formatFailure(report: plugin.TestReportFailedLeaf, padding: string, maxLength: number): string {
     let lines: string[] = [];
 
@@ -41,7 +58,7 @@ export class TestResultFormatterImp implements TestResultFormatter {
         lines.push(`${os.EOL}${this.decorator.line(givenMessage)}${os.EOL}`);
       }
 
-      let message = this.formatFailureMessage(resultMessage.message, maxLength!);
+      let message = this.formatFailureMessage(resultMessage.message, maxLength);
       lines.push(this.formatMessage(message, padding));
     });
 
@@ -52,6 +69,10 @@ export class TestResultFormatterImp implements TestResultFormatter {
       .replace(new RegExp(TestResultFormatterImp.verticalBarStart, "g"), this.decorator.verticalBarStart())
       .replace(new RegExp(TestResultFormatterImp.verticalBarMiddle, "g"), this.decorator.verticalBarMiddle())
       .replace(new RegExp(TestResultFormatterImp.verticalBarEnd, "g"), this.decorator.verticalBarEnd());
+
+    if (report.logMessages && report.logMessages.length > 0) {
+      return output;
+    }
 
     return output + os.EOL;
   }

--- a/lib/test-result-formatter.ts
+++ b/lib/test-result-formatter.ts
@@ -37,11 +37,9 @@ export class TestResultFormatterImp implements TestResultFormatter {
 
     let output: string = "";
 
-    if (report.logMessages && report.logMessages.length > 0) {
-      _.forEach(report.logMessages, (logMessage: string) => {
-        output += `${padding}${this.decorator.rightArrow()} ${this.decorator.debugLog(logMessage)}${os.EOL}`;
-      });
-    }
+    _.forEach(report.logMessages, (logMessage: string) => {
+      output += `${padding}${this.decorator.rightArrow()} ${this.decorator.debugLog(logMessage)}${os.EOL}`;
+    });
 
     return output + os.EOL;
   }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
     "test-unit-coveralls": "cd test/unit && nyc mocha --opts mocha.opts --reporter dot && nyc report --reporter=text-lcov | coveralls",
     "test-integration": "cd test/integration && mocha --opts mocha.opts",
     "test": "npm run test-lint && npm run test-unit --silent && npm run test-integration --silent",
-    "test-ci": "npm run test-lint && npm run test-unit-ci --silent && npm run test-integration --silent"
+    "test-ci": "npm run test-lint && npm run test-unit-ci --silent && npm run test-integration --silent",
+    "verify-elm-test": "cd test/integration/elm-test && rm -f -r tests/elm-stuff/build-artifacts && ../../../bin/lobo.js --framework=elm-test $*",
+    "verify-elm-test-extra": "cd test/integration/elm-test-extra && rm -f -r tests/elm-stuff/build-artifacts && ../../../bin/lobo.js --framework=elm-test-extra $*"
   }
 }

--- a/plugin/default-reporter/plugin-config.ts
+++ b/plugin/default-reporter/plugin-config.ts
@@ -4,6 +4,7 @@ export class DefaultReporterConfig implements PluginConfig {
   public name: string = "default-reporter";
 
   public options: PluginOption[] = [
+    {flags: "--hideDebugMessages", description: "prevent reporting of any test Debug.log messages"},
     {flags: "--showSkip", description: "report skipped tests after the summary"},
     {flags: "--showTodo", description: "report todo tests after the summary"}
   ];

--- a/plugin/junit-reporter/reporter-plugin.ts
+++ b/plugin/junit-reporter/reporter-plugin.ts
@@ -10,6 +10,7 @@ import {createTestResultDecoratorHtml} from "../../lib/test-result-decorator-htm
 import {createTestResultDecoratorText} from "../../lib/test-result-decorator-text";
 import {createTestResultFormatter, TestResultFormatter} from "../../lib/test-result-formatter";
 import {createReporterStandardConsole, ReporterStandardConsole} from "../../lib/reporter-standard-console";
+import {TestReportLogged} from "../../lib/plugin";
 
 type JUnitFormat = "console" | "html";
 
@@ -208,25 +209,53 @@ export class JUnitReporter implements plugin.PluginReporter {
       + ` classname="${parentLabel}">`);
 
     writeLine(`${padding}${this.paddingUnit}<failure>`);
-
-    if (this.junitFormat === "html") {
-      this.writeFailureAsHtml(writeLine, leaf, padding);
-    } else {
-      this.writeFailureAsText(writeLine, leaf, padding);
-    }
-
+    let failureMessage = this.toFailureLogMessage(leaf);
+    this.writeMessage(writeLine, failureMessage, padding);
     writeLine(`${padding}${this.paddingUnit}</failure>`);
+    this.writeDebugLogMessage(writeLine, leaf, padding);
     writeLine(`${padding}</testcase>`);
   }
 
-  public writeFailureAsText(writeLine: WriteLine, leaf: plugin.TestReportFailedLeaf, padding: string): void {
-    let message = this.textFormatter.formatFailure(leaf, "", this.diffMaxLength);
-    writeLine(`${padding}${this.paddingUnit}${this.paddingUnit}${message}`);
+  public writeMessage(writeLine: WriteLine, message: string, padding: string): void {
+    if (this.junitFormat === "html") {
+      this.writeAsHtml(writeLine, message, padding);
+    } else {
+      this.writeAsText(writeLine, message);
+    }
   }
 
-  public writeFailureAsHtml(writeLine: WriteLine, leaf: plugin.TestReportFailedLeaf, padding: string): void {
-    let message = this.htmlFormatter.formatFailure(leaf, "", this.diffMaxLength);
+  public writeDebugLogMessage(writeLine: WriteLine, leaf: TestReportLogged, padding: string): void {
+    if (!leaf.logMessages || leaf.logMessages.length === 0) {
+      return;
+    }
 
+    writeLine(`${padding}${this.paddingUnit}<system-out>`);
+    let debugLogMessages = this.toDebugLogMessage(leaf);
+    this.writeMessage(writeLine, debugLogMessages, padding);
+    writeLine(`${padding}${this.paddingUnit}</system-out>`);
+  }
+
+  public toDebugLogMessage(leaf: plugin.TestReportLogged): string {
+    if (this.junitFormat === "html") {
+      return this.htmlFormatter.formatDebugLogMessages(leaf, "");
+    }
+
+    return this.textFormatter.formatDebugLogMessages(leaf, "");
+  }
+
+  public toFailureLogMessage(leaf: plugin.TestReportFailedLeaf): string {
+    if (this.junitFormat === "html") {
+      return this.htmlFormatter.formatFailure(<plugin.TestReportFailedLeaf> leaf, "", this.diffMaxLength);
+    }
+
+    return this.textFormatter.formatFailure(<plugin.TestReportFailedLeaf> leaf, "", this.diffMaxLength);
+  }
+
+  public writeAsText(writeLine: WriteLine, message: string): void {
+    writeLine(message);
+  }
+
+  public writeAsHtml(writeLine: WriteLine, message: string, padding: string): void {
     writeLine(`${padding}${this.paddingUnit}${this.paddingUnit}<![CDATA[`);
     writeLine(`${padding}${this.paddingUnit}${this.paddingUnit}${this.paddingUnit}<pre style="overflow:auto">`);
     writeLine(`<code style="display:inline-block; line-height:1">${message}`);
@@ -244,6 +273,7 @@ export class JUnitReporter implements plugin.PluginReporter {
   public writePassed(writeLine: WriteLine, parentLabel: string, leaf: plugin.TestReportPassedLeaf, padding: string): void {
     writeLine(`${padding}<testcase name="${leaf.label}" time="${JUnitReporter.getDurationSecondsFrom(leaf)}" `
       + `classname="${parentLabel}">`);
+    this.writeDebugLogMessage(writeLine, leaf, padding);
     writeLine(`${padding}</testcase>`);
   }
 

--- a/plugin/junit-reporter/reporter-plugin.ts
+++ b/plugin/junit-reporter/reporter-plugin.ts
@@ -5,7 +5,6 @@ import * as fs from "fs";
 import * as os from "os";
 import * as plugin from "../../lib/plugin";
 import {WriteStream} from "fs";
-import {createTestResultDecoratorConsole} from "../../lib/test-result-decorator-console";
 import {createTestResultDecoratorHtml} from "../../lib/test-result-decorator-html";
 import {createTestResultDecoratorText} from "../../lib/test-result-decorator-text";
 import {createTestResultFormatter, TestResultFormatter} from "../../lib/test-result-formatter";
@@ -27,7 +26,6 @@ type WriteLine  = (line: string) => void;
 
 export class JUnitReporter implements plugin.PluginReporter {
 
-  private consoleFormatter: TestResultFormatter;
   private htmlFormatter: TestResultFormatter;
   private textFormatter: TestResultFormatter;
   private standardConsole: ReporterStandardConsole;
@@ -47,11 +45,10 @@ export class JUnitReporter implements plugin.PluginReporter {
   }
 
   constructor(logger: plugin.PluginReporterLogger, paddingUnit: string, standardConsole: ReporterStandardConsole,
-              consoleFormatter: TestResultFormatter, htmlFormatter: TestResultFormatter, textFormatter: TestResultFormatter) {
+              htmlFormatter: TestResultFormatter, textFormatter: TestResultFormatter) {
     this.logger = logger;
     this.paddingUnit = paddingUnit;
     this.standardConsole = standardConsole;
-    this.consoleFormatter = consoleFormatter;
     this.htmlFormatter = htmlFormatter;
     this.textFormatter = textFormatter;
 
@@ -325,9 +322,8 @@ export class JUnitReporter implements plugin.PluginReporter {
 }
 
 export function createPlugin(): plugin.PluginReporter {
-  let consoleFormatter = createTestResultFormatter(createTestResultDecoratorConsole());
   let htmlFormatter = createTestResultFormatter(createTestResultDecoratorHtml());
   let textFormatter = createTestResultFormatter(createTestResultDecoratorText());
 
-  return new JUnitReporter(console, "  ", createReporterStandardConsole(), consoleFormatter, htmlFormatter, textFormatter);
+  return new JUnitReporter(console, "  ", createReporterStandardConsole(), htmlFormatter, textFormatter);
 }

--- a/runner/TestReporter.elm
+++ b/runner/TestReporter.elm
@@ -1,6 +1,6 @@
 module TestReporter exposing (TestReport, encodeReports, toProgressMessage, toTestReport)
 
-import Json.Encode exposing (Value, encode, float, list, null, object, string)
+import Json.Encode exposing (Value, encode, float, int, list, null, object, string)
 import TestPlugin exposing (Args, FailureMessage, TestId, TestIdentifier, TestItem, TestResult(Fail, Ignore, Pass, Skip, Todo), TestRunType(Focusing, Normal, Skipping))
 import Time exposing (Time)
 
@@ -146,7 +146,8 @@ toProgressMessage testReport =
 encodeProgressMessage : String -> TestId -> Value
 encodeProgressMessage resultType id =
     object
-    [ ( "label", string id.current.label )
+    [ ( "id", int id.current.uniqueId)
+    , ( "label", string id.current.label )
     , ( "resultType", string resultType )
     ]
 
@@ -591,7 +592,8 @@ encodeTestReportNode reportTree =
 encodeFailedLeaf : FailedLeaf -> Value
 encodeFailedLeaf leaf =
     object
-        [ ( "label", string leaf.label )
+        [ ( "id", int leaf.id)
+        , ( "label", string leaf.label )
         , ( "resultType", string resultType.failed )
         , ( "resultMessages", list (List.map encodeFailureMessage leaf.messages) )
         , ( "startTime", float leaf.startTime )
@@ -602,7 +604,8 @@ encodeFailedLeaf leaf =
 encodeIgnoredLeaf : IgnoredLeaf -> Value
 encodeIgnoredLeaf leaf =
     object
-        [ ( "label", string leaf.label )
+        [ ( "id", int leaf.id)
+        , ( "label", string leaf.label )
         , ( "resultType", string resultType.ignored )
         ]
 
@@ -610,7 +613,8 @@ encodeIgnoredLeaf leaf =
 encodePassedLeaf : PassedLeaf -> Value
 encodePassedLeaf leaf =
     object
-        [ ( "label", string leaf.label )
+        [ ( "id", int leaf.id)
+        , ( "label", string leaf.label )
         , ( "resultType", string resultType.passed )
         , ( "startTime", float leaf.startTime )
         , ( "endTime", float leaf.endTime )
@@ -620,7 +624,8 @@ encodePassedLeaf leaf =
 encodeSkippedLeaf : SkippedLeaf -> Value
 encodeSkippedLeaf leaf =
     object
-        [ ( "label", string leaf.label )
+        [ ( "id", int leaf.id)
+        , ( "label", string leaf.label )
         , ( "resultType", string resultType.skipped )
         , ( "reason", string leaf.reason )
         ]
@@ -629,7 +634,8 @@ encodeSkippedLeaf leaf =
 encodeRootNode : Value -> SuiteNode -> Value
 encodeRootNode config node =
     object
-        [ ( "runType", string <| toRunType node.runType )
+        [ ( "id", int node.id)
+        , ( "runType", string <| toRunType node.runType )
         , ( "config", config )
         , ( "runResults", encodeTestReportNodeList node.reports )
         , ( "startTime", encodeMaybeTime node.startTime )
@@ -640,7 +646,8 @@ encodeRootNode config node =
 encodeSuiteNode : SuiteNode -> Value
 encodeSuiteNode node =
     object
-        [ ( "label", string node.label )
+        [ ( "id", int node.id)
+        , ( "label", string node.label )
         , ( "results", encodeTestReportNodeList node.reports )
         , ( "startTime", encodeMaybeTime node.startTime )
         , ( "endTime", encodeMaybeTime node.endTime )
@@ -650,7 +657,8 @@ encodeSuiteNode node =
 encodeTodoLeaf : TodoLeaf -> Value
 encodeTodoLeaf leaf =
     object
-        [ ( "label", string leaf.label )
+        [ ( "id", int leaf.id)
+        , ( "label", string leaf.label )
         , ( "resultType", string resultType.todo )
         ]
 

--- a/runner/TestRunner.elm
+++ b/runner/TestRunner.elm
@@ -133,10 +133,7 @@ update msg model =
                 next =
                     StartTest |> updateTime
             in
-                if model.runArgs.reportProgress then
-                    ( newModel, Cmd.batch [ progress (toProgressMessage testReport), next ] )
-                else
-                    ( newModel, next )
+                ( newModel, Cmd.batch [ progress (toProgressMessage testReport), next ] )
 
         Finished ->
             let

--- a/test/integration/elm-test-extra/simple.test.ts
+++ b/test/integration/elm-test-extra/simple.test.ts
@@ -36,16 +36,52 @@ describe("elm-test-extra-simple", () => {
     });
   });
 
-  describe("fail", () => {
-    let testDirectory: string;
+  describe("debug", () => {
+    let testFile: string;
 
     beforeEach(() => {
-      testDirectory = "simple/fail/Tests.elm";
+      testFile = "simple/debug/Tests.elm";
+    });
+
+    it("should show Debug.log messages by default", () => {
+      // act
+      let result = runner.run(testContext, "elm-test-extra", testFile);
+
+      // assert
+      let firstTestIndex = result.stdout.indexOf("1) failing Debug.log test");
+      let secondTestIndex = result.stdout.indexOf("2) passing Debug.log test");
+      let failureMessage = result.stdout.substring(firstTestIndex, secondTestIndex);
+      expect(failureMessage).to.have.string("→ Bar: \"Hello Bar\"");
+
+      failureMessage = result.stdout.substring(secondTestIndex, result.stdout.length - 1);
+      expect(failureMessage).to.have.string("→ Foo: \"Hello Foo\"");
+    });
+
+    it("should not show Debug.log messages when --hideDebugMessages is supplied", () => {
+      // act
+      let result = runner.run(testContext, "elm-test", testFile, "--hideDebugMessages");
+
+      // assert
+      let startIndex = result.stdout
+        .indexOf("================================================================================");
+      let failureMessage = result.stdout.substring(startIndex, result.stdout.length - 1);
+
+      expect(failureMessage).not.to.have.string("→ Bar: \"Hello Bar\"");
+      expect(failureMessage).not.to.have.string("2) passing Debug.log test");
+      expect(failureMessage).not.to.have.string("→ Foo: \"Hello Foo\"");
+    });
+  });
+
+  describe("fail", () => {
+    let testFile: string;
+
+    beforeEach(() => {
+      testFile = "simple/fail/Tests.elm";
     });
 
     it("should report failure", () => {
       // act
-      let result = runner.run(testContext, "elm-test-extra", testDirectory);
+      let result = runner.run(testContext, "elm-test-extra", testFile);
 
       // assert
       reporterExpect(result).summaryFailed();
@@ -55,7 +91,7 @@ describe("elm-test-extra-simple", () => {
 
     it("should update message to use ┌ └  instead of ╷ ╵", () => {
       // act
-      let result = runner.run(testContext, "elm-test-extra", testDirectory);
+      let result = runner.run(testContext, "elm-test-extra", testFile);
 
       // assert
       let startIndex = result.stdout
@@ -70,7 +106,7 @@ describe("elm-test-extra-simple", () => {
 
     it("should update string equals to show diff hint", () => {
       // act
-      let result = runner.run(testContext, "elm-test-extra", testDirectory);
+      let result = runner.run(testContext, "elm-test-extra", testFile);
 
       // assert
       let startIndex = result.stdout
@@ -86,15 +122,15 @@ describe("elm-test-extra-simple", () => {
   });
 
   describe("fuzz", () => {
-    let testDirectory: string;
+    let testFile: string;
 
     beforeEach(() => {
-      testDirectory = "simple/fuzz/Tests.elm";
+      testFile = "simple/fuzz/Tests.elm";
     });
 
     it("should report success", () => {
       // act
-      let result = runner.run(testContext, "elm-test-extra", testDirectory);
+      let result = runner.run(testContext, "elm-test-extra", testFile);
 
       // assert
       reporterExpect(result).summaryPassed();
@@ -107,7 +143,7 @@ describe("elm-test-extra-simple", () => {
       let expectedRunCount = 11;
 
       // act
-      let result = runner.run(testContext, "elm-test-extra", testDirectory, "--runCount=" + expectedRunCount);
+      let result = runner.run(testContext, "elm-test-extra", testFile, "--runCount=" + expectedRunCount);
 
       // assert
       reporterExpect(result).summaryPassed();
@@ -129,7 +165,7 @@ describe("elm-test-extra-simple", () => {
       let initialSeed = 101;
 
       // act
-      let result = runner.run(testContext, "elm-test-extra", testDirectory, "--seed=" + initialSeed);
+      let result = runner.run(testContext, "elm-test-extra", testFile, "--seed=" + initialSeed);
 
       // assert
       reporterExpect(result).summaryPassed();

--- a/test/integration/elm-test-extra/tests/simple/debug/Tests.elm
+++ b/test/integration/elm-test-extra/tests/simple/debug/Tests.elm
@@ -1,0 +1,34 @@
+module Tests exposing (all)
+
+import Expect exposing (equal)
+import ElmTest.Extra exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "Tests"
+        [ testDebugFail
+        , testDebugPass
+        ]
+
+
+testDebugPass : Test
+testDebugPass =
+    test "passing Debug.log test" <|
+        \() ->
+            toGreeting "Foo"
+            |> Expect.equal "Hello Foo"
+
+
+testDebugFail : Test
+testDebugFail =
+    test "failing Debug.log test" <|
+        \() ->
+            toGreeting "Bar"
+            |> Expect.equal "Hello Foo"
+
+
+toGreeting: String -> String
+toGreeting name =
+    "Hello " ++ name
+    |> Debug.log name

--- a/test/integration/elm-test-extra/tests/simple/nested/ChildTest.elm
+++ b/test/integration/elm-test-extra/tests/simple/nested/ChildTest.elm
@@ -1,6 +1,5 @@
 module ChildTest exposing (all)
 
-import Expect exposing (pass)
 import GrandChildTest exposing (all)
 import ElmTest.Extra exposing (Test, describe, test)
 

--- a/test/integration/elm-test/simple.test.ts
+++ b/test/integration/elm-test/simple.test.ts
@@ -36,16 +36,52 @@ describe("elm-test-simple", () => {
     });
   });
 
-  describe("fail", () => {
-    let testDirectory: string;
+  describe("debug", () => {
+    let testFile: string;
 
     beforeEach(() => {
-      testDirectory = "simple/fail/Tests.elm";
+      testFile = "simple/debug/Tests.elm";
+    });
+
+    it("should show Debug.log messages by default", () => {
+      // act
+      let result = runner.run(testContext, "elm-test", testFile);
+
+      // assert
+      let firstTestIndex = result.stdout.indexOf("1) failing Debug.log test");
+      let secondTestIndex = result.stdout.indexOf("2) passing Debug.log test");
+      let failureMessage = result.stdout.substring(firstTestIndex, secondTestIndex);
+      expect(failureMessage).to.have.string("→ Bar: \"Hello Bar\"");
+
+      failureMessage = result.stdout.substring(secondTestIndex, result.stdout.length - 1);
+      expect(failureMessage).to.have.string("→ Foo: \"Hello Foo\"");
+    });
+
+    it("should not show Debug.log messages when --hideDebugMessages is supplied", () => {
+      // act
+      let result = runner.run(testContext, "elm-test", testFile, "--hideDebugMessages");
+
+      // assert
+      let startIndex = result.stdout
+        .indexOf("================================================================================");
+      let failureMessage = result.stdout.substring(startIndex, result.stdout.length - 1);
+
+      expect(failureMessage).not.to.have.string("→ Bar: \"Hello Bar\"");
+      expect(failureMessage).not.to.have.string("2) passing Debug.log test");
+      expect(failureMessage).not.to.have.string("→ Foo: \"Hello Foo\"");
+    });
+  });
+
+  describe("fail", () => {
+    let testFile: string;
+
+    beforeEach(() => {
+      testFile = "simple/fail/Tests.elm";
     });
 
     it("should report failure", () => {
       // act
-      let result = runner.run(testContext, "elm-test", testDirectory);
+      let result = runner.run(testContext, "elm-test", testFile);
 
       // assert
       reporterExpect(result).summaryFailed();
@@ -55,7 +91,7 @@ describe("elm-test-simple", () => {
 
     it("should update message to use ┌ └  instead of ╷ ╵", () => {
       // act
-      let result = runner.run(testContext, "elm-test", testDirectory);
+      let result = runner.run(testContext, "elm-test", testFile);
 
       // assert
       let startIndex = result.stdout
@@ -70,7 +106,7 @@ describe("elm-test-simple", () => {
 
     it("should update string equals to show diff hint", () => {
       // act
-      let result = runner.run(testContext, "elm-test", testDirectory);
+      let result = runner.run(testContext, "elm-test", testFile);
 
       // assert
       let startIndex = result.stdout
@@ -86,15 +122,15 @@ describe("elm-test-simple", () => {
   });
 
   describe("fuzz", () => {
-    let testDirectory: string;
+    let testFile: string;
 
     beforeEach(() => {
-      testDirectory = "simple/fuzz/Tests.elm";
+      testFile = "simple/fuzz/Tests.elm";
     });
 
     it("should report success", () => {
       // act
-      let result = runner.run(testContext, "elm-test", testDirectory);
+      let result = runner.run(testContext, "elm-test", testFile);
 
       // assert
       reporterExpect(result).summaryPassed();
@@ -107,7 +143,7 @@ describe("elm-test-simple", () => {
       let expectedRunCount = 11;
 
       // act
-      let result = runner.run(testContext, "elm-test", testDirectory, "--runCount=" + expectedRunCount);
+      let result = runner.run(testContext, "elm-test", testFile, "--runCount=" + expectedRunCount);
 
       // assert
       reporterExpect(result).summaryPassed();
@@ -129,7 +165,7 @@ describe("elm-test-simple", () => {
       let initialSeed = 101;
 
       // act
-      let result = runner.run(testContext, "elm-test", testDirectory, "--seed=" + initialSeed);
+      let result = runner.run(testContext, "elm-test", testFile, "--seed=" + initialSeed);
 
       // assert
       reporterExpect(result).summaryPassed();

--- a/test/integration/elm-test/tests/simple/debug/Tests.elm
+++ b/test/integration/elm-test/tests/simple/debug/Tests.elm
@@ -1,0 +1,34 @@
+module Tests exposing (all)
+
+import Expect exposing (equal)
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "Tests"
+        [ testDebugFail
+        , testDebugPass
+        ]
+
+
+testDebugPass : Test
+testDebugPass =
+    test "passing Debug.log test" <|
+        \() ->
+            toGreeting "Foo"
+            |> Expect.equal "Hello Foo"
+
+
+testDebugFail : Test
+testDebugFail =
+    test "failing Debug.log test" <|
+        \() ->
+            toGreeting "Bar"
+            |> Expect.equal "Hello Foo"
+
+
+toGreeting: String -> String
+toGreeting name =
+    "Hello " ++ name
+    |> Debug.log name

--- a/test/integration/elm-test/tests/simple/nested/ChildTest.elm
+++ b/test/integration/elm-test/tests/simple/nested/ChildTest.elm
@@ -1,6 +1,5 @@
 module ChildTest exposing (all)
 
-import Expect exposing (pass)
 import GrandChildTest exposing (all)
 import Test exposing (Test, describe, test)
 

--- a/test/integration/mocha.opts
+++ b/test/integration/mocha.opts
@@ -1,6 +1,6 @@
---compilers ts:ts-node/register
 --full-trace
 --recursive **/*.test.ts
+--require ts-node/register
 --require source-map-support/register
 --timeout 100000
 

--- a/test/unit/lib/reporter-standard-console.test.ts
+++ b/test/unit/lib/reporter-standard-console.test.ts
@@ -37,6 +37,7 @@ describe("lib reporter-standard-console", () => {
     };
     mockFormatter = <TestResultFormatter> {
       defaultIndentation: () => "",
+      formatDebugLogMessages: Sinon.stub(),
       formatFailure: Sinon.stub(),
       formatNotRun: Sinon.stub(),
       formatUpdate: Sinon.stub()

--- a/test/unit/lib/runner.test.ts
+++ b/test/unit/lib/runner.test.ts
@@ -96,6 +96,24 @@ describe("lib runner", () => {
       expect(mockReject).to.have.been.calledWith(expected);
     });
 
+    it("should return a function that set stdout.write to originalNodeProcessWrite when an error is thrown", () => {
+      // arrange
+      let expected = new Error("foo");
+      mockReporter.init = () => {
+        throw expected;
+      };
+      let mockWrite = Sinon.spy();
+      mockStdout.write = Sinon.spy();
+      RunnerImp.originalNodeProcessWrite = mockWrite;
+
+      // act
+      let actual = RunnerImp.makeTestRunBegin(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(123);
+
+      // assert
+      expect(mockStdout.write).to.equal(mockWrite);
+    });
+
     it("should set the originalNodeProcessWrite to value of stdout.write", () => {
       // arrange
       mockReporter.init = Sinon.spy();
@@ -180,6 +198,24 @@ describe("lib runner", () => {
 
       // assert
       expect(mockReject).to.have.been.calledWith(expected);
+    });
+
+    it("should return a function that set stdout.write to originalNodeProcessWrite when an error is thrown", () => {
+      // arrange
+      let expected = new Error("foo");
+      mockReporter.update = () => {
+        throw expected;
+      };
+      let mockWrite = Sinon.spy();
+      mockStdout.write = Sinon.spy();
+      RunnerImp.originalNodeProcessWrite = mockWrite;
+
+      // act
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(<ProgressReport> {});
+
+      // assert
+      expect(mockStdout.write).to.equal(mockWrite);
     });
 
     it("should return a function that restore stdout.write to the original value before calling reporter.update", () => {
@@ -282,6 +318,27 @@ describe("lib runner", () => {
 
       // assert
       expect(mockReject).to.have.been.calledWith();
+    });
+
+    it("should return a function that set stdout.write to originalNodeProcessWrite when an error is thrown", () => {
+      // arrange
+      mockReporter.finish = Sinon.stub();
+      (<SinonStub>mockReporter.finish).returns({
+        then: () => {
+          return {"catch": func => func()};
+        }
+      });
+      let expected = <TestReportRoot> {runType: "NORMAL"};
+      let mockWrite = Sinon.spy();
+      mockStdout.write = Sinon.spy();
+      RunnerImp.originalNodeProcessWrite = mockWrite;
+
+      // act
+      let actual = RunnerImp.makeTestRunComplete(mockStdout, mockLogger, mockReporter, mockResolve, mockReject);
+      actual(expected);
+
+      // assert
+      expect(mockStdout.write).to.equal(mockWrite);
     });
 
     it("should return a function that resets the stdout.write to the originalNodeProcessWrite value", () => {

--- a/test/unit/lib/runner.test.ts
+++ b/test/unit/lib/runner.test.ts
@@ -6,7 +6,7 @@ import rewire = require("rewire");
 import * as SinonChai from "sinon-chai";
 import {SinonStub} from "sinon";
 import {Logger} from "../../../lib/logger";
-import {createRunner, NodeProcessStdout, NodeProcessWrite, Runner, RunnerImp} from "../../../lib/runner";
+import {createRunner, NodeProcessStdout, Runner, RunnerImp} from "../../../lib/runner";
 import {Reporter} from "../../../lib/reporter";
 import {LoboConfig, PluginReporter, PluginTestFramework, ProgressReport, TestReportRoot} from "../../../lib/plugin";
 
@@ -22,10 +22,10 @@ describe("lib runner", () => {
   let mockResolve: () => void;
   let mockReporter: Reporter;
   let mockStdout: NodeProcessStdout;
-  let originalWrite: NodeProcessWrite;
+  let revertRunner;
 
   beforeEach(() => {
-    originalWrite = process.stdout.write;
+    revertRunner = RewiredRunner.__set__({process: {stdout: { write: Sinon.spy()}} });
     let rewiredImp = RewiredRunner.__get__("RunnerImp");
     mockLogger = <Logger> {};
     mockLogger.debug = Sinon.spy();
@@ -41,7 +41,7 @@ describe("lib runner", () => {
   });
 
   afterEach(() => {
-    (<NodeProcessStdout>process.stdout).write = originalWrite;
+    revertRunner();
   });
 
   describe("createRunner", () => {

--- a/test/unit/lib/runner.test.ts
+++ b/test/unit/lib/runner.test.ts
@@ -6,12 +6,13 @@ import rewire = require("rewire");
 import * as SinonChai from "sinon-chai";
 import {SinonStub} from "sinon";
 import {Logger} from "../../../lib/logger";
-import {createRunner, Runner, RunnerImp} from "../../../lib/runner";
+import {createRunner, NodeProcessStdout, NodeProcessWrite, Runner, RunnerImp} from "../../../lib/runner";
 import {Reporter} from "../../../lib/reporter";
 import {LoboConfig, PluginReporter, PluginTestFramework, ProgressReport, TestReportRoot} from "../../../lib/plugin";
 
 let expect = chai.expect;
 chai.use(SinonChai);
+chai.use(require("chai-things"));
 
 describe("lib runner", () => {
   let RewiredRunner = rewire("../../../lib/runner");
@@ -20,18 +21,27 @@ describe("lib runner", () => {
   let mockReject: (error: Error) => void;
   let mockResolve: () => void;
   let mockReporter: Reporter;
+  let mockStdout: NodeProcessStdout;
+  let originalWrite: NodeProcessWrite;
 
   beforeEach(() => {
+    originalWrite = process.stdout.write;
     let rewiredImp = RewiredRunner.__get__("RunnerImp");
     mockLogger = <Logger> {};
     mockLogger.debug = Sinon.spy();
     mockLogger.info = Sinon.spy();
     mockLogger.trace = Sinon.spy();
+    mockStdout = <NodeProcessStdout> {};
+    mockStdout.write = Sinon.spy();
     mockReporter = <Reporter> {};
     runner = new rewiredImp(mockLogger, mockReporter);
 
     mockReject = Sinon.spy();
     mockResolve = Sinon.spy();
+  });
+
+  afterEach(() => {
+    (<NodeProcessStdout>process.stdout).write = originalWrite;
   });
 
   describe("createRunner", () => {
@@ -64,7 +74,7 @@ describe("lib runner", () => {
       mockReporter.init = Sinon.spy();
 
       // act
-      let actual = RunnerImp.makeTestRunBegin(mockLogger, mockReporter, mockReject);
+      let actual = RunnerImp.makeTestRunBegin(mockStdout, mockLogger, mockReporter, mockReject);
       actual(123);
 
       // assert
@@ -79,11 +89,52 @@ describe("lib runner", () => {
       };
 
       // act
-      let actual = RunnerImp.makeTestRunBegin(mockLogger, mockReporter, mockReject);
+      let actual = RunnerImp.makeTestRunBegin(mockStdout, mockLogger, mockReporter, mockReject);
       actual(123);
 
       // assert
       expect(mockReject).to.have.been.calledWith(expected);
+    });
+
+    it("should set the originalNodeProcessWrite to value of stdout.write", () => {
+      // arrange
+      mockReporter.init = Sinon.spy();
+      let mockWrite = Sinon.spy();
+      mockStdout.write = mockWrite;
+
+      // act
+      let actual = RunnerImp.makeTestRunBegin(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(123);
+
+      // assert
+      expect(RunnerImp.originalNodeProcessWrite).to.equal(mockWrite);
+    });
+
+    it("should set stdout.write to RunnerImp.testRunStdOutWrite", () => {
+      // arrange
+      mockReporter.init = Sinon.spy();
+      let mockWrite = Sinon.spy();
+      mockStdout.write = mockWrite;
+
+      // act
+      let actual = RunnerImp.makeTestRunBegin(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(123);
+
+      // assert
+      expect(mockStdout.write).to.equal(RunnerImp.testRunStdOutWrite);
+    });
+
+    it("should initialize the debugLogMessage list to an empty array", () => {
+      // arrange
+      mockReporter.init = Sinon.spy();
+      RunnerImp.debugLogMessages = ["foo"];
+
+      // act
+      let actual = RunnerImp.makeTestRunBegin(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(123);
+
+      // assert
+      expect(RunnerImp.debugLogMessages).to.be.empty;
     });
   });
 
@@ -94,11 +145,26 @@ describe("lib runner", () => {
       let expected = <ProgressReport> {reason: "foobar"};
 
       // act
-      let actual = RunnerImp.makeTestRunProgress(mockLogger, mockReporter, mockReject);
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
       actual(expected);
 
       // assert
-      expect(mockReporter.update).to.have.been.calledWith(expected);
+      expect(mockReporter.update).to.have.been.calledWith(expected, Sinon.match.any);
+    });
+
+    it("should return a function that calls reporter.update with the accumulated Debug.log messages", () => {
+      // arrange
+      mockReporter.update = Sinon.spy();
+      let progressReport = <ProgressReport> {reason: "foobar"};
+      let expected = ["baz"];
+      RunnerImp.debugLogMessages = expected;
+
+      // act
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(progressReport);
+
+      // assert
+      expect(mockReporter.update).to.have.been.calledWith(Sinon.match.any, expected);
     });
 
     it("should return a function that calls supplied reject when an error is thrown", () => {
@@ -109,11 +175,55 @@ describe("lib runner", () => {
       };
 
       // act
-      let actual = RunnerImp.makeTestRunProgress(mockLogger, mockReporter, mockReject);
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
       actual(<ProgressReport> {});
 
       // assert
       expect(mockReject).to.have.been.calledWith(expected);
+    });
+
+    it("should return a function that restore stdout.write to the original value before calling reporter.update", () => {
+      // arrange
+      let original = Sinon.spy();
+      RunnerImp.originalNodeProcessWrite = original;
+
+      mockReporter.update = Sinon.stub();
+      (<SinonStub>mockReporter.update).callsFake(() => {
+        expect(mockStdout.write).to.equal(original);
+      });
+
+      // act
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(<ProgressReport> {});
+
+      // assert -- see arrange
+    });
+
+    it("should return a function that leaves stdout.write set to testRunStdOutWrite after it has been called", () => {
+      // arrange
+      let original = Sinon.spy();
+      RunnerImp.originalNodeProcessWrite = original;
+      mockReporter.update = Sinon.stub();
+
+      // act
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(<ProgressReport> {});
+
+      // assert
+      expect(mockStdout.write).to.equal(RunnerImp.testRunStdOutWrite);
+    });
+
+    it("should return a function that clears the debugLogMessages after it has been called", () => {
+      // arrange
+      RunnerImp.debugLogMessages = ["foo"];
+      mockReporter.update = Sinon.stub();
+
+      // act
+      let actual = RunnerImp.makeTestRunProgress(mockStdout, mockLogger, mockReporter, mockReject);
+      actual(<ProgressReport> {});
+
+      // assert
+      expect(RunnerImp.debugLogMessages).to.be.empty;
     });
   });
 
@@ -130,7 +240,7 @@ describe("lib runner", () => {
       let expected = <TestReportRoot> {runType: "NORMAL"};
 
       // act
-      let actual = RunnerImp.makeTestRunComplete(mockLogger, mockReporter, mockResolve, mockReject);
+      let actual = RunnerImp.makeTestRunComplete(mockStdout, mockLogger, mockReporter, mockResolve, mockReject);
       actual(expected);
 
       // assert
@@ -149,7 +259,7 @@ describe("lib runner", () => {
       let expected = <TestReportRoot> {runType: "NORMAL"};
 
       // act
-      let actual = RunnerImp.makeTestRunComplete(mockLogger, mockReporter, mockResolve, mockReject);
+      let actual = RunnerImp.makeTestRunComplete(mockStdout, mockLogger, mockReporter, mockResolve, mockReject);
       actual(expected);
 
       // assert
@@ -167,11 +277,55 @@ describe("lib runner", () => {
       let expected = <TestReportRoot> {runType: "NORMAL"};
 
       // act
-      let actual = RunnerImp.makeTestRunComplete(mockLogger, mockReporter, mockResolve, mockReject);
+      let actual = RunnerImp.makeTestRunComplete(mockStdout, mockLogger, mockReporter, mockResolve, mockReject);
       actual(expected);
 
       // assert
       expect(mockReject).to.have.been.calledWith();
+    });
+
+    it("should return a function that resets the stdout.write to the originalNodeProcessWrite value", () => {
+      // arrange
+      let original = Sinon.spy();
+      RunnerImp.originalNodeProcessWrite = original;
+      mockReporter.finish = Sinon.stub();
+      (<SinonStub>mockReporter.finish).returns({
+        then: func => {
+          func();
+          return {"catch": Sinon.stub()};
+        }
+      });
+
+      // act
+      let actual = RunnerImp.makeTestRunComplete(mockStdout, mockLogger, mockReporter, mockResolve, mockReject);
+      actual(<TestReportRoot> {runType: "NORMAL"});
+
+      // assert
+      expect(mockStdout.write).to.equal(original);
+    });
+  });
+
+  describe("testRunStdOutWrite", () => {
+    it("should add supplied message to the debugLogMessages list", () => {
+      // arrange
+      RunnerImp.debugLogMessages = [];
+
+      // act
+      RunnerImp.testRunStdOutWrite("foo");
+
+      // assert
+      expect(RunnerImp.debugLogMessages).to.include.something.that.equals("foo");
+    });
+
+    it("should return true", () => {
+      // arrange
+      RunnerImp.debugLogMessages = [];
+
+      // act
+      let actual = RunnerImp.testRunStdOutWrite(undefined);
+
+      // assert
+      expect(actual).to.be.true;
     });
   });
 

--- a/test/unit/lib/test-result-decorator-console.test.ts
+++ b/test/unit/lib/test-result-decorator-console.test.ts
@@ -15,11 +15,13 @@ describe("lib test-result-decorator-console", () => {
   let RewiredDecorator = rewire("../../../lib/test-result-decorator-console");
   let rewiredImp;
   let decorator: TestResultDecoratorConsoleImp;
+  let mockCyanStyle: SinonStub;
   let mockRedStyle: SinonStub;
   let mockGreenStyle: SinonStub;
   let mockYellowStyle: SinonStub;
 
   beforeEach(() => {
+    mockCyanStyle = Sinon.stub();
     mockRedStyle = Sinon.stub();
     mockGreenStyle = Sinon.stub();
     mockYellowStyle = Sinon.stub();
@@ -27,6 +29,7 @@ describe("lib test-result-decorator-console", () => {
     RewiredDecorator.__set__({
       chalk_1: {
         "default": {
+          cyan: mockCyanStyle,
           green: mockGreenStyle,
           red: mockRedStyle,
           yellow: mockYellowStyle
@@ -132,6 +135,16 @@ describe("lib test-result-decorator-console", () => {
     });
   });
 
+  describe("rightArrow", () => {
+    it("should be →", () => {
+      // act
+      let actual = decorator.rightArrow();
+
+      // assert
+      expect(actual).to.equal("→");
+    });
+  });
+
   describe("verticalBarEnd", () => {
     it("should be └", () => {
       // act
@@ -159,6 +172,19 @@ describe("lib test-result-decorator-console", () => {
 
       // assert
       expect(actual).to.equal("┌");
+    });
+  });
+
+  describe("debugLog", () => {
+    it("should return value styled with cyan", () => {
+      // arrange
+      mockCyanStyle.callsFake(x => x + "bar");
+
+      // act
+      let actual = decorator.debugLog("foo");
+
+      // assert
+      expect(actual).to.equal("foobar");
     });
   });
 

--- a/test/unit/lib/test-result-decorator-html.test.ts
+++ b/test/unit/lib/test-result-decorator-html.test.ts
@@ -113,6 +113,16 @@ describe("lib test-result-decorator-html", () => {
     });
   });
 
+  describe("rightArrow", () => {
+    it("should be &rarr;", () => {
+      // act
+      let actual = decorator.rightArrow();
+
+      // assert
+      expect(actual).to.equal("&rarr;");
+    });
+  });
+
   describe("verticalBarEnd", () => {
     it("should be &boxur;", () => {
       // act
@@ -140,6 +150,16 @@ describe("lib test-result-decorator-html", () => {
 
       // assert
       expect(actual).to.equal("&boxdr;");
+    });
+  });
+
+  describe("debugLog", () => {
+    it("should return value styled with dark cyan span", () => {
+      // act
+      let actual = decorator.debugLog("foo");
+
+      // assert
+      expect(actual).to.equal("<span style=\"color:darkcyan\">foo</span>");
     });
   });
 

--- a/test/unit/lib/test-result-decorator-text.test.ts
+++ b/test/unit/lib/test-result-decorator-text.test.ts
@@ -113,6 +113,16 @@ describe("lib test-result-decorator-text", () => {
     });
   });
 
+  describe("rightArrow", () => {
+    it("should be →", () => {
+      // act
+      let actual = decorator.rightArrow();
+
+      // assert
+      expect(actual).to.equal("→");
+    });
+  });
+
   describe("verticalBarEnd", () => {
     it("should be └", () => {
       // act
@@ -140,6 +150,16 @@ describe("lib test-result-decorator-text", () => {
 
       // assert
       expect(actual).to.equal("┌");
+    });
+  });
+
+  describe("debugLog", () => {
+    it("should return value unaltered", () => {
+      // act
+      let actual = decorator.debugLog("foo");
+
+      // assert
+      expect(actual).to.equal("foo");
     });
   });
 

--- a/test/unit/lib/test-result-formatter.test.ts
+++ b/test/unit/lib/test-result-formatter.test.ts
@@ -115,7 +115,15 @@ describe("lib test-result-formatter", () => {
       expect(actual).to.match(/\n\n$/);
     });
 
-    it("should return empty when there are no log messages", () => {
+    it("should return empty when logMessages is undefined", () => {
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportLogged> {logMessages: undefined}, "?");
+
+      // assert
+      expect(actual).to.equal("");
+    });
+
+    it("should return empty when logMessages is empty", () => {
       // act
       let actual = formatter.formatDebugLogMessages(<TestReportLogged> {logMessages: []}, "?");
 

--- a/test/unit/lib/test-result-formatter.test.ts
+++ b/test/unit/lib/test-result-formatter.test.ts
@@ -8,7 +8,7 @@ import * as SinonChai from "sinon-chai";
 import {createTestResultFormatter, TestResultFormatter, TestResultFormatterImp} from "../../../lib/test-result-formatter";
 import {Comparer} from "../../../lib/comparer";
 import {
-  FailureMessage, ProgressReport, ResultType, TestReportFailedLeaf, TestReportSkippedLeaf, TestResultDecorator
+  FailureMessage, ProgressReport, ResultType, TestReportFailedLeaf, TestReportLogged, TestReportSkippedLeaf, TestResultDecorator
 } from "../../../lib/plugin";
 
 let expect = chai.expect;
@@ -27,11 +27,13 @@ describe("lib test-result-formatter", () => {
     mockComparer = <Comparer> {diff: Sinon.stub()};
     mockDecorator = <TestResultDecorator><{}>{
       bulletPoint: Sinon.stub(),
+      debugLog: Sinon.stub(),
       diff: Sinon.stub(),
       expect: Sinon.stub(),
       failed: Sinon.stub(),
       given: Sinon.stub(),
       line: Sinon.stub(),
+      rightArrow: Sinon.stub(),
       skip: Sinon.stub(),
       todo: Sinon.stub(),
       verticalBarEnd: Sinon.stub(),
@@ -49,6 +51,76 @@ describe("lib test-result-formatter", () => {
 
       // assert
       expect(actual).to.exist;
+    });
+  });
+
+  describe("formatDebugLogMessages", () => {
+    it("should return the formatted log messages from the supplied log messages", () => {
+      // arrange
+      (<SinonStub>mockDecorator.debugLog).callsFake(x => x);
+      (<SinonStub>mockDecorator.rightArrow).callsFake(() => "::");
+
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportFailedLeaf> {logMessages: ["foo", "bar"]}, "?");
+
+      // assert
+      expect(actual).to.match(/foo(\n|.)*bar/);
+    });
+
+    it("should return the message with supplied padding prefix", () => {
+      // arrange
+      (<SinonStub>mockDecorator.debugLog).callsFake(x => x);
+      (<SinonStub>mockDecorator.rightArrow).callsFake(() => "::");
+
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportFailedLeaf> {logMessages: ["foo"]}, "?");
+
+      // assert
+      expect(actual).to.match(/^\?::/);
+    });
+
+    it("should return the message prefixed with decorator right arrow value", () => {
+      // arrange
+      (<SinonStub>mockDecorator.debugLog).callsFake(x => x);
+      (<SinonStub>mockDecorator.rightArrow).callsFake(() => "::");
+
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportFailedLeaf> {logMessages: ["foo"]}, "?");
+
+      // assert
+      expect(actual).to.match(/:: foo/);
+    });
+
+    it("should return the message with debugLog styling applied by decorator", () => {
+      // arrange
+      (<SinonStub>mockDecorator.debugLog).callsFake(x => "-" + x + "-");
+      (<SinonStub>mockDecorator.rightArrow).callsFake(() => "::");
+
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportFailedLeaf> {logMessages: ["foo"]}, "?");
+
+      // assert
+      expect(actual).to.match(/-foo-/);
+    });
+
+    it("should return the failure ending with 2 new lines when there are log messages", () => {
+      // arrange
+      (<SinonStub>mockDecorator.debugLog).callsFake(x => x);
+      (<SinonStub>mockDecorator.rightArrow).callsFake(() => "::");
+
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportLogged> {logMessages: ["foo"]}, "?");
+
+      // assert
+      expect(actual).to.match(/\n\n$/);
+    });
+
+    it("should return empty when there are no log messages", () => {
+      // act
+      let actual = formatter.formatDebugLogMessages(<TestReportLogged> {logMessages: []}, "?");
+
+      // assert
+      expect(actual).to.equal("");
     });
   });
 
@@ -162,6 +234,35 @@ describe("lib test-result-formatter", () => {
       // assert
       expect(actual).not.to.match(/┌/);
       expect(actual).to.match(/::foo::/);
+    });
+
+    it("should return the failure ending with 2 new lines when there are no log messages", () => {
+      // arrange
+      (<SinonStub>mockDecorator.expect).callsFake(x => x);
+      (<SinonStub>mockDecorator.verticalBarStart).callsFake(() => "::");
+      let expected = <FailureMessage>{message: "┌foo┌"};
+      formatter.formatMessage = (x, y) => x;
+
+      // act
+      let actual = formatter.formatFailure(<TestReportFailedLeaf> {logMessages: [],  resultMessages: [expected]}, "?", 123);
+
+      // assert
+      expect(actual).to.match(/\n\n$/);
+    });
+
+    it("should return the failure not ending with 1 new line when there are log messages", () => {
+      // arrange
+      (<SinonStub>mockDecorator.expect).callsFake(x => x);
+      (<SinonStub>mockDecorator.verticalBarStart).callsFake(() => "::");
+      let expected = <FailureMessage>{message: "┌foo┌"};
+      formatter.formatMessage = (x, y) => x;
+
+      // act
+      let actual = formatter.formatFailure(<TestReportFailedLeaf> {logMessages: ["bar"], resultMessages: [expected]}, "?", 123);
+
+      // assert
+      expect(actual).not.to.match(/\n\n$/);
+      expect(actual).to.match(/\n$/);
     });
   });
 

--- a/test/unit/plugin/default-reporter/plugin-config.test.ts
+++ b/test/unit/plugin/default-reporter/plugin-config.test.ts
@@ -16,6 +16,14 @@ describe("plugin default-reporter plugin-config", () => {
   });
 
   describe("options", () => {
+    it("should have '--hideDebugMessages' option", () => {
+      // act'
+      let options = config.options;
+
+      // assert
+      expect(options).to.include.something.that.property("flags", "--hideDebugMessages");
+    });
+
     it("should have '--showSkip' option", () => {
       // act'
       let options = config.options;

--- a/test/unit/plugin/junit-reporter/reporter-plugin.test.ts
+++ b/test/unit/plugin/junit-reporter/reporter-plugin.test.ts
@@ -27,7 +27,6 @@ describe("plugin junit-reporter reporter-plugin", () => {
   let reporter: JUnitReporter;
   let mockLogger: { log(message: string): void };
   let mockStandardConsole: ReporterStandardConsole;
-  let mockConsoleFormatter: TestResultFormatter;
   let mockHtmlFormatter: TestResultFormatter;
   let mockTextFormatter: TestResultFormatter;
   let mockCreateWriteStream: SinonStub;
@@ -44,11 +43,10 @@ describe("plugin junit-reporter reporter-plugin", () => {
       runArgs: Sinon.stub(),
       update: Sinon.stub()
     };
-    mockConsoleFormatter = <TestResultFormatter><{}>{formatDebugLogMessages: Sinon.stub(), formatUpdate: Sinon.stub()};
     mockHtmlFormatter = <TestResultFormatter><{}>{formatDebugLogMessages: Sinon.stub(), formatFailure: Sinon.stub()};
     mockTextFormatter = <TestResultFormatter><{}>{formatDebugLogMessages: Sinon.stub(), formatFailure: Sinon.stub()};
     mockWriteLine = Sinon.stub();
-    reporter = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+    reporter = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
   });
 
   describe("createPlugin", () => {
@@ -68,7 +66,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
 
       // act
-      let actual = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let actual = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       actual.writeFailure(mockWriteLine, "foo", <TestReportFailedLeaf> {label: "bar"}, "::");
 
       // assert
@@ -896,7 +894,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       rep.writeAsHtml = Sinon.spy();
 
       // act
@@ -910,7 +908,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       rep.writeAsHtml = Sinon.spy();
 
       // act
@@ -924,7 +922,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       rep.writeAsHtml = Sinon.spy();
 
       // act
@@ -938,7 +936,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       rep.writeAsText = Sinon.spy();
 
       // act
@@ -952,7 +950,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       rep.writeAsText = Sinon.spy();
 
       // act
@@ -1027,7 +1025,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       let expected = <TestReportFailedLeaf> {label: "bar"};
 
       // act
@@ -1041,7 +1039,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
 
       // act
       rep.toDebugLogMessage(<TestReportFailedLeaf> {label: "bar"});
@@ -1054,7 +1052,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       let expected = <TestReportFailedLeaf> {label: "bar"};
 
       // act
@@ -1068,7 +1066,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
 
       // act
       rep.toDebugLogMessage(<TestReportFailedLeaf> {label: "bar"});
@@ -1083,7 +1081,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       let expected = <TestReportFailedLeaf> {label: "bar"};
 
       // act
@@ -1097,7 +1095,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
 
       // act
       rep.toFailureLogMessage(<TestReportFailedLeaf> {label: "bar"});
@@ -1110,7 +1108,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {diffMaxLength: 123, junitFormat: "html"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
 
       // act
       rep.toFailureLogMessage(<TestReportFailedLeaf> {label: "bar"});
@@ -1123,7 +1121,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
       let expected = <TestReportFailedLeaf> {label: "bar"};
 
       // act
@@ -1137,7 +1135,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
 
       // act
       rep.toFailureLogMessage(<TestReportFailedLeaf> {label: "bar"});
@@ -1150,7 +1148,7 @@ describe("plugin junit-reporter reporter-plugin", () => {
       // arrange
       RewiredPlugin.__set__({program: {diffMaxLength: 123, junitFormat: "text"}});
       let rewiredImp = RewiredPlugin.__get__("JUnitReporter");
-      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockConsoleFormatter, mockHtmlFormatter, mockTextFormatter);
+      let rep = new rewiredImp(mockLogger, "*", mockStandardConsole, mockHtmlFormatter, mockTextFormatter);
 
       // act
       rep.toFailureLogMessage(<TestReportFailedLeaf> {label: "bar"});


### PR DESCRIPTION
As discussed in #15 Debug.log messages appeared during the run of tests mixed in with the progress messages. 

This change delays output of Debug.log messages such that they are emitted after all of the tests have completed and appear in context of which test produced them.  