### PR TITLE
Fixes bug when test file contains Navigation.program 

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions">
+    <TaskOptions isEnabled="true">
+      <option name="arguments" value="$FilePath$ --yes" />
+      <option name="checkSyntaxErrors" value="true" />
+      <option name="description" />
+      <option name="exitCodeBehavior" value="ERROR" />
+      <option name="fileExtension" value="elm" />
+      <option name="immediateSync" value="false" />
+      <option name="name" value="elm-format" />
+      <option name="output" value="" />
+      <option name="outputFilters">
+        <array />
+      </option>
+      <option name="outputFromStdout" value="false" />
+      <option name="program" value="elm-format" />
+      <option name="runOnExternalChanges" value="true" />
+      <option name="scopeName" value="Project Files" />
+      <option name="trackOnlyRoot" value="false" />
+      <option name="workingDir" value="" />
+      <envs />
+    </TaskOptions>
+  </component>
+</project>

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -285,7 +285,7 @@ export class BuilderImp implements Builder {
 
   public runElmPackageInstall(config: LoboConfig, directory: string, prompt: boolean, resolve: Resolve, reject: Reject): void {
     if (config.noInstall) {
-      this.logger.info("Ignored running of elm-package due to configuration");
+      this.logger.info("Ignored running of elm-package install due to configuration");
       resolve();
       return;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lobo",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Elm test runner",
   "keywords": [
     "elm",

--- a/test/integration/elm-lang/elm-lang.test.ts
+++ b/test/integration/elm-lang/elm-lang.test.ts
@@ -31,7 +31,7 @@ describe("elm-lang", () => {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(1, 0);
+      reporterExpect(result).summaryCounts(2, 0);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-lang/src/ImportNavigation.elm
+++ b/test/integration/elm-lang/src/ImportNavigation.elm
@@ -1,0 +1,61 @@
+module ImportNavigation exposing (..)
+
+{--
+ Test for a file that contains Navigation.program
+
+ Note: Internally Navigation.program calls Navigation.getLocation that assumes the
+ global object document.location exists
+ --}
+
+import Html exposing (Html, div)
+import Navigation
+
+
+-- PROGRAM
+
+
+main : Program Never Model Msg
+main =
+    Navigation.program OnLocationChange
+        { view = view
+        , init = init
+        , update = update
+        , subscriptions = always Sub.none
+        }
+
+
+
+-- MODEL
+
+
+type alias Model =
+    {}
+
+
+init : Navigation.Location -> ( Model, Cmd Msg )
+init location =
+    ( {}, Cmd.none )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = None
+    | OnLocationChange Navigation.Location
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    ( model, Cmd.none )
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        []

--- a/test/integration/elm-lang/tests/Tests.elm
+++ b/test/integration/elm-lang/tests/Tests.elm
@@ -1,12 +1,30 @@
 module Tests exposing (all)
 
 import Expect exposing (pass)
-import Test exposing (Test, test)
 import ImportCheck
+import ImportNavigation
+import Test exposing (Test, describe, test)
 
 
 all : Test
 all =
-    test "passingTest" <|
+    describe "Tests"
+        [ testImportCheck
+        , testImportNavigation
+        ]
+
+
+testImportCheck : Test
+testImportCheck =
+    test "test import check" <|
         \() ->
-            Expect.pass
+            Expect.true "truthy" ImportCheck.truthy
+
+
+testImportNavigation : Test
+testImportNavigation =
+    test "test import navigation" <|
+        \() ->
+            ImportNavigation.update ImportNavigation.None {}
+                |> Tuple.second
+                |> Expect.equal Cmd.none

--- a/test/unit/lib/runner.test.ts
+++ b/test/unit/lib/runner.test.ts
@@ -57,14 +57,14 @@ describe("lib runner", () => {
   describe("loadElmTestApp", () => {
     it("should the loaded elm test app", () => {
       // act
-      let actual = runner.loadElmTestApp("./runner");
+      let actual = runner.loadElmTestApp("./runner", mockLogger);
 
       // assert
       expect(actual).to.exist;
     });
 
     it("should throw an error when the elm test app is not found", () => {
-      expect(() => runner.loadElmTestApp("./foo")).to.throw("Elm program not found");
+      expect(() => runner.loadElmTestApp("./foo", mockLogger)).to.throw("Failed to load test file");
     });
   });
 


### PR DESCRIPTION
Fix for #20 by adding document.location to the list of global objects that the tests expect to exist