### PR TITLE
Fixes bug when UrlParser.parsePath is used in init

### DIFF
--- a/.idea/runConfigurations/Debug___elm_lang.xml
+++ b/.idea/runConfigurations/Debug___elm_lang.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug - elm-lang" type="NodeJSConfigurationType" factoryName="Node.js" application-parameters="--framework=elm-test --prompt=no --testFile=Tests.elm --veryVerbose" node-parameters="-r ts-node/register" path-to-js-file="$PROJECT_DIR$/bin/lobo.ts" working-dir="$PROJECT_DIR$/test/integration/elm-lang">
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Debug___elm_test_extra.xml
+++ b/.idea/runConfigurations/Debug___elm_test_extra.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug - elm-test-extra" type="NodeJSConfigurationType" factoryName="Node.js" application-parameters="--framework=elm-test-extra --prompt=no --testFile=simple/fail/Tests.elm" node-parameters="-r ts-node/register" path-to-js-file="$PROJECT_DIR$/bin/lobo.ts" working-dir="$PROJECT_DIR$/test/integration/elm-test-extra">
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Integration___elm_lang.xml
+++ b/.idea/runConfigurations/Integration___elm_lang.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration - elm-lang" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$/test/integration</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="PATH" value="$USER_HOME$/.nvm/versions/node/v6.11.2/bin:/usr/bin:/usr/local/bin" />
+      <env name="disableClean" value="true" />
+      <env name="noisyTestRun" value="true" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register --timeout 100000</extra-mocha-options>
+    <test-kind>SUITE</test-kind>
+    <test-file>$PROJECT_DIR$/test/integration/elm-lang/elm-lang.test.ts</test-file>
+    <test-names>
+      <name value="elm-lang" />
+    </test-names>
+    <method />
+  </configuration>
+</component>

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -128,7 +128,7 @@ export class RunnerImp {
       logger.info("-----------------------------------[ TEST ]-------------------------------------");
 
       // add to the global scope browser global properties that are used by elm imports
-      (<BrowserGlobal>global).document = { location: { hash: "#", pathname: "/", search: "?" } };
+      (<BrowserGlobal>global).document = { location: { hash: "", pathname: "", search: "" } };
       (<BrowserGlobal>global).window = { navigator: {} };
 
       let elmApp = this.loadElmTestApp(config.testFile, logger);

--- a/lib/runner.ts
+++ b/lib/runner.ts
@@ -28,7 +28,11 @@ export interface NodeProcessStdout {
 
 export interface BrowserGlobal extends NodeJS.Global {
   document: { // required by Dom & Navigation
-    location: object // required by Navigation
+    location: { // required by Navigation & UrlParser
+      hash: string,
+      pathname: string,
+      search: string
+    }
   };
   window: { // required by AnimationFrame & Navigation
     navigator: object // required by Navigation
@@ -108,8 +112,8 @@ export class RunnerImp {
       app = require(testFile);
       // tslint:enable:no-require-imports
     } catch (err) {
-      logger.debug("Failed to require test file", err);
-      throw new Error("Failed to load test file" + testFile);
+      logger.debug("Failed to require test file", testFile);
+      throw err;
     }
 
     return app;
@@ -124,7 +128,7 @@ export class RunnerImp {
       logger.info("-----------------------------------[ TEST ]-------------------------------------");
 
       // add to the global scope browser global properties that are used by elm imports
-      (<BrowserGlobal>global).document = { location: {} };
+      (<BrowserGlobal>global).document = { location: { hash: "#", pathname: "/", search: "?" } };
       (<BrowserGlobal>global).window = { navigator: {} };
 
       let elmApp = this.loadElmTestApp(config.testFile, logger);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lobo",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Elm test runner",
   "keywords": [
     "elm",

--- a/test/integration/elm-lang/elm-lang.test.ts
+++ b/test/integration/elm-lang/elm-lang.test.ts
@@ -31,7 +31,7 @@ describe("elm-lang", () => {
 
       // assert
       reporterExpect(result).summaryPassed();
-      reporterExpect(result).summaryCounts(2, 0);
+      reporterExpect(result).summaryCounts(3, 0);
       expect(result.code).to.equal(0);
     });
   });

--- a/test/integration/elm-lang/elm-package.json
+++ b/test/integration/elm-lang/elm-package.json
@@ -21,7 +21,8 @@
         "elm-lang/trampoline": "1.0.1 <= v < 2.0.0",
         "elm-lang/virtual-dom": "2.0.0 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
-        "elm-lang/window": "1.0.1 <= v < 2.0.0"
+        "elm-lang/window": "1.0.1 <= v < 2.0.0",
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/test/integration/elm-lang/src/ImportNavigation.elm
+++ b/test/integration/elm-lang/src/ImportNavigation.elm
@@ -9,6 +9,7 @@ module ImportNavigation exposing (..)
 
 import Html exposing (Html, div)
 import Navigation
+import UrlParser
 
 
 -- PROGRAM
@@ -29,12 +30,27 @@ main =
 
 
 type alias Model =
-    {}
+    { route : Maybe Route }
+
+
+type Route
+    = AppRoute
+
+
+routeParser : UrlParser.Parser (Route -> a) a
+routeParser =
+    UrlParser.s "foo"
+        |> UrlParser.map AppRoute
+
+
+parseLocation : Navigation.Location -> Maybe Route
+parseLocation location =
+    UrlParser.parsePath routeParser location
 
 
 init : Navigation.Location -> ( Model, Cmd Msg )
 init location =
-    ( {}, Cmd.none )
+    ( { route = parseLocation location }, Cmd.none )
 
 
 

--- a/test/integration/elm-lang/tests/Tests.elm
+++ b/test/integration/elm-lang/tests/Tests.elm
@@ -11,6 +11,7 @@ all =
     describe "Tests"
         [ testImportCheck
         , testImportNavigation
+        , testImportNavigationInit
         ]
 
 
@@ -25,6 +26,27 @@ testImportNavigation : Test
 testImportNavigation =
     test "test import navigation" <|
         \() ->
-            ImportNavigation.update ImportNavigation.None {}
+            ImportNavigation.update ImportNavigation.None { route = Nothing }
+                |> Tuple.second
+                |> Expect.equal Cmd.none
+
+
+testImportNavigationInit : Test
+testImportNavigationInit =
+    test "test import navigation init" <|
+        \() ->
+            { href = "https://somebody:secret@example.com:123/foo/bar?id=baz#qux"
+            , host = "example.com:123"
+            , hostname = "example.com"
+            , protocol = "https"
+            , origin = "https://example.com"
+            , port_ = "123"
+            , pathname = "/foo/bar"
+            , search = "?id=baz"
+            , hash = "#qux"
+            , username = "somebody"
+            , password = "secret"
+            }
+                |> ImportNavigation.init
                 |> Tuple.second
                 |> Expect.equal Cmd.none

--- a/test/unit/lib/main.test.ts
+++ b/test/unit/lib/main.test.ts
@@ -1616,6 +1616,62 @@ describe("lib main", () => {
         "caused by an elm package using objects that are found in the browser but not in a node process");
     });
 
+    it("should log unknown type error for missing browser objects correctly", () => {
+      // arrange
+      let error = new TypeError();
+      error.stack = "foo";
+      let config = <LoboConfig> {testFile: "foo"};
+
+      // act
+      lobo.handleUncaughtException(error, config);
+
+      // assert
+      expect(mockLogger.error).to.have.been.calledWith("Error running the tests. This is usually " +
+        "caused by an elm package using objects that are found in the browser but not in a node process");
+    });
+
+    it("should not ask for rerun with verbose option when verbose is set", () => {
+      // arrange
+      let error = new TypeError();
+      error.stack = "foo";
+      let config = <LoboConfig> {testFile: "foo"};
+      let revert = rewiredMain.__with__({program: {verbose: true}});
+
+      // act
+      revert(() => lobo.handleUncaughtException(error, config));
+
+      // assert
+      expect(mockLogger.error).to.have.been.not.calledWith("Please rerun lobo with the --verbose option to see the cause of the error");
+    });
+
+    it("should not ask for rerun with verbose option when veryVerbose is set", () => {
+      // arrange
+      let error = new TypeError();
+      error.stack = "foo";
+      let config = <LoboConfig> {testFile: "foo"};
+      let revert = rewiredMain.__with__({program: {veryVerbose: true}});
+
+      // act
+      revert(() => lobo.handleUncaughtException(error, config));
+
+      // assert
+      expect(mockLogger.error).to.have.been.not.calledWith("Please rerun lobo with the --verbose option to see the cause of the error");
+    });
+
+    it("should ask for rerun with verbose option when verbose is not set", () => {
+      // arrange
+      let error = new TypeError();
+      error.stack = "foo";
+      let config = <LoboConfig> {testFile: "foo"};
+      let revert = rewiredMain.__with__({program: {verbose: false}});
+
+      // act
+      revert(() => lobo.handleUncaughtException(error, config));
+
+      // assert
+      expect(mockLogger.error).to.have.been.calledWith("Please rerun lobo with the --verbose option to see the cause of the error");
+    });
+
     it("should not exit the process when there is an error and in watch mode", () => {
       // arrange
       let error = new Error();

--- a/test/unit/lib/runner.test.ts
+++ b/test/unit/lib/runner.test.ts
@@ -64,7 +64,7 @@ describe("lib runner", () => {
     });
 
     it("should throw an error when the elm test app is not found", () => {
-      expect(() => runner.loadElmTestApp("./foo", mockLogger)).to.throw("Failed to load test file");
+      expect(() => runner.loadElmTestApp("./foo", mockLogger)).to.throw("Cannot find module './foo'");
     });
   });
 


### PR DESCRIPTION
Fix for #20 by setting location.hash, location.pathname, location.search to empty string